### PR TITLE
Add view loan command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ViewLoanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewLoanCommand.java
@@ -1,0 +1,71 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.LoanRecords;
+import seedu.address.model.person.Person;
+
+/**
+ * Represents a command to view the loans associated with a contact.
+ */
+public class ViewLoanCommand extends Command {
+    public static final String COMMAND_WORD = "viewLoan";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": View loans associated with the person identified by the index used in the displayed person list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_SUCCESS = "Listed all loans associated with: %1$s";
+    private final Index targetIndex;
+
+    public ViewLoanCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToShowLoan = lastShownList.get(targetIndex.getZeroBased());
+        LoanRecords loanRecords = personToShowLoan.getLoanRecords();
+
+        // TODO model.updateLoanList or something
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(personToShowLoan)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ViewLoanCommand)) {
+            return false;
+        }
+
+        ViewLoanCommand otherViewLoanCommand = (ViewLoanCommand) other;
+        return targetIndex.equals(otherViewLoanCommand.targetIndex);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("targetIndex", targetIndex)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -8,7 +8,17 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.logic.commands.*;
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.LinkLoanCommand;
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ViewLoanCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -8,15 +8,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.ClearCommand;
-import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.ExitCommand;
-import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.*;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -76,6 +68,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case ViewLoanCommand.COMMAND_WORD:
+            return new ViewLoanCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -8,16 +8,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.ClearCommand;
-import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.ExitCommand;
-import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.LinkLoanCommand;
-import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.*;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -80,6 +71,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case ViewLoanCommand.COMMAND_WORD:
+            return new ViewLoanCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/ViewLoanCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewLoanCommandParser.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.ViewLoanCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ViewLoanCommand object
+ */
+public class ViewLoanCommandParser implements Parser<ViewLoanCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ViewLoanCommand
+     * and returns a ViewLoanCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ViewLoanCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new ViewLoanCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewLoanCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/address/ui/LoanCard.java
+++ b/src/main/java/seedu/address/ui/LoanCard.java
@@ -1,0 +1,51 @@
+package seedu.address.ui;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import seedu.address.model.person.Loan;
+
+import java.util.Comparator;
+
+/**
+ * An UI component that displays information of a {@code Loan}.
+ */
+public class LoanCard extends UiPart<Region> {
+    private static final String FXML = "LoanListCard.fxml";
+
+    /**
+     * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
+     * As a consequence, UI elements' variable names cannot be set to such keywords
+     * or an exception will be thrown by JavaFX during runtime.
+     *
+     * @see <a href="https://github.com/se-edu/addressbook-level4/issues/336">The issue on AddressBook level 4</a>
+     */
+
+    public final Loan loan;
+    private static final String DEFAULT_LOAN_PREFIX = "Loan No. ";
+
+    @javafx.fxml.FXML
+    private HBox cardPane;
+    @FXML
+    private Label name;
+    @FXML
+    private Label amount;
+    @FXML
+    private Label startDate;
+    @FXML
+    private Label endDate;
+
+    /**
+     * Creates a {@code LoanCard} with the given {@code Loan} and index to display.
+     */
+    public LoanCard(Loan loan, int displayedIndex) {
+        super(FXML);
+        this.loan = loan;
+        name.setText(DEFAULT_LOAN_PREFIX + displayedIndex);
+        amount.setText(String.valueOf(loan.getAmount()));
+        startDate.setText(loan.getStartDate().toString());
+        endDate.setText(loan.getEndDate().toString());
+    }
+}

--- a/src/main/java/seedu/address/ui/LoanCard.java
+++ b/src/main/java/seedu/address/ui/LoanCard.java
@@ -2,18 +2,19 @@ package seedu.address.ui;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
-import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.person.Loan;
-
-import java.util.Comparator;
 
 /**
  * An UI component that displays information of a {@code Loan}.
  */
 public class LoanCard extends UiPart<Region> {
     private static final String FXML = "LoanListCard.fxml";
+    private static final String DEFAULT_LOAN_PREFIX = "Loan No. ";
+    private static final String DEFAULT_AMOUNT_PREFIX = "Amount: ";
+    private static final String DEFAULT_START_DATE_PREFIX = "Start Date: ";
+    private static final String DEFAULT_END_DATE_PREFIX = "End Date: ";
 
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
@@ -24,7 +25,6 @@ public class LoanCard extends UiPart<Region> {
      */
 
     public final Loan loan;
-    private static final String DEFAULT_LOAN_PREFIX = "Loan No. ";
 
     @javafx.fxml.FXML
     private HBox cardPane;
@@ -44,8 +44,8 @@ public class LoanCard extends UiPart<Region> {
         super(FXML);
         this.loan = loan;
         name.setText(DEFAULT_LOAN_PREFIX + displayedIndex);
-        amount.setText(String.valueOf(loan.getAmount()));
-        startDate.setText(loan.getStartDate().toString());
-        endDate.setText(loan.getEndDate().toString());
+        amount.setText(DEFAULT_AMOUNT_PREFIX + String.valueOf(loan.getValue()));
+        startDate.setText(DEFAULT_START_DATE_PREFIX + loan.getStartDate().toString());
+        endDate.setText(DEFAULT_END_DATE_PREFIX + loan.getReturnDate().toString());
     }
 }

--- a/src/main/resources/view/LoanListCard.fxml
+++ b/src/main/resources/view/LoanListCard.fxml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.FlowPane?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.VBox?>
+
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+  <GridPane HBox.hgrow="ALWAYS">
+    <columnConstraints>
+      <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
+    </columnConstraints>
+    <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+      <padding>
+        <Insets top="5" right="5" bottom="5" left="15" />
+      </padding>
+      <HBox spacing="5" alignment="CENTER_LEFT">
+        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+      </HBox>
+      <Label fx:id="amount" styleClass="cell_small_label" text="\$amount" />
+      <Label fx:id="startDate" styleClass="cell_small_label" text="\$startDate" />
+      <Label fx:id="endDate" styleClass="cell_small_label" text="\$endDate" />
+    </VBox>
+  </GridPane>
+</HBox>


### PR DESCRIPTION
~~This is partially resolving Issue 30.~~
Edit: Resolves issue #49 
Added a view loan command.

- Usage: `viewLoan INDEX`, where `INDEX` is the index of the person in the `lastShownPersonList`.
- Expected behaviour: Success text displayed in the `ResultDisplay` box, but no change in GUI at all.

Implementation details:

- `ViewLoanCommand.execute()` needs to be updated after GUI has been incorporated. Right now it does not modify GUI.
- An UI component, `LoanCard` class is created in analogy to `PersonCard`. This has not been incorporated into GUI because currently `PersonListView` does not support loans, because it uses a `FilteredList<Person>`.