### PR TITLE
Change "link" command to "linkloan"

### DIFF
--- a/src/main/java/seedu/address/logic/commands/LinkLoanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LinkLoanCommand.java
@@ -22,7 +22,7 @@ import seedu.address.model.person.Person;
  */
 public class LinkLoanCommand extends Command {
 
-    public static final String COMMAND_WORD = "link";
+    public static final String COMMAND_WORD = "linkloan";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Links a loan to the person identified "
             + "by the index number used in the displayed person list. "


### PR DESCRIPTION
Fixes #44.

Changes the `link` command to `linkloan`, in order to standardise with @xiaorui-ui PR #40.