### PR TITLE
Fix display logic errors in DeleteLoanCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteLoanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteLoanCommand.java
@@ -7,7 +7,9 @@ import java.util.List;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.Loan;
 import seedu.address.model.person.LoanRecords;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 
 /**
@@ -19,13 +21,13 @@ public class DeleteLoanCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Delete the specified loan index of the person who is identified"
             + "by the index number. "
-            + "Parameters: INDEX(must be positive integer), LOAN_INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1 + l/1";
+            + "Parameters: INDEX (must be a positive integer), LOAN_INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1 " + "l/1";
 
     public static final String MESSAGE_NOT_IMPLEMENTED_YET =
             "Delete loan command not implemented yet";
     public static final String MESSAGE_ARGUMENTS = "Person number: %1$d, Loan Index: %2$d";
-    public static final String MESSAGE_SUCCESS = "Loan deleted: Person number: %1$d, Loan Index: %2$d";
+    public static final String MESSAGE_SUCCESS = "Loan deleted: Person Name: %1$s, Loan: %2$s";
     public static final String MESSAGE_FAILURE_PERSON = "No person found for Person number: %1$d";
     public static final String MESSAGE_FAILURE_LOAN = "No loan found for Loan number: %1$d for given person";
     private final Index personIndex;
@@ -54,8 +56,9 @@ public class DeleteLoanCommand extends Command {
         }
         LoanRecords loanRecords = personToEdit.getLoanRecords();
         // delete specified loan number
-        loanRecords.removeLoan(loanRecords.getLoan(loanIndex.getZeroBased()));
-        return new CommandResult(generateSuccessMessage(personIndex.getOneBased(), loanIndex.getOneBased()));
+        Loan loanToRemove = loanRecords.getLoan(loanIndex.getZeroBased());
+        loanRecords.removeLoan(loanToRemove);
+        return new CommandResult(generateSuccessMessage(personToEdit.getName(), loanToRemove));
     }
 
     /**
@@ -63,9 +66,8 @@ public class DeleteLoanCommand extends Command {
      * the remark is added to or removed from
      * {@code personToEdit}.
      */
-    private String generateSuccessMessage(int personIndex, int loanIndex) {
-        return String.format(MESSAGE_SUCCESS, "Person number ", personIndex, ", Loan number ", loanIndex,
-                " successfully removed!");
+    private String generateSuccessMessage(Name personName, Loan removedLoan) {
+        return String.format(MESSAGE_SUCCESS, personName, removedLoan);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteLoanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteLoanCommand.java
@@ -27,7 +27,7 @@ public class DeleteLoanCommand extends Command {
     public static final String MESSAGE_NOT_IMPLEMENTED_YET =
             "Delete loan command not implemented yet";
     public static final String MESSAGE_ARGUMENTS = "Person number: %1$d, Loan Index: %2$d";
-    public static final String MESSAGE_SUCCESS = "Loan deleted: Person Name: %1$s, Loan: %2$s";
+    public static final String MESSAGE_SUCCESS = "Loan deleted.\nPerson Name: %1$s\nLoan: %2$s";
     public static final String MESSAGE_FAILURE_PERSON = "No person found for Person number: %1$d";
     public static final String MESSAGE_FAILURE_LOAN = "No loan found for Loan number: %1$d for given person";
     private final Index personIndex;

--- a/src/main/java/seedu/address/logic/commands/DeleteLoanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteLoanCommand.java
@@ -27,7 +27,9 @@ public class DeleteLoanCommand extends Command {
     public static final String MESSAGE_NOT_IMPLEMENTED_YET =
             "Delete loan command not implemented yet";
     public static final String MESSAGE_ARGUMENTS = "Person number: %1$d, Loan Index: %2$d";
-    public static final String MESSAGE_SUCCESS = "Loan deleted.\nPerson Name: %1$s\nLoan: %2$s";
+    public static final String MESSAGE_SUCCESS = "Loan deleted.\n"
+            + "Person Name: %1$s\n"
+            + "Loan: %2$s";
     public static final String MESSAGE_FAILURE_PERSON = "No person found for Person number: %1$d";
     public static final String MESSAGE_FAILURE_LOAN = "No loan found for Loan number: %1$d for given person";
     private final Index personIndex;


### PR DESCRIPTION
Fixes #47.

During a `deleteloan` command,
- Corrects the logic of the formatting such that it now converts the person and loan details to an appropriate success message.
- Changes the success message from displaying person and loan index to displaying person name and deleted loan details.
- Fixed some typos in the failure message.