### PR TITLE
Improve error handling

### DIFF
--- a/src/main/java/seedu/address/commons/util/DateUtil.java
+++ b/src/main/java/seedu/address/commons/util/DateUtil.java
@@ -11,7 +11,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
  */
 public class DateUtil {
 
-    private static final String DATE_FORMAT = "yyyy-MM-dd";
+    public static final String DATE_FORMAT = "yyyy-MM-dd";
     private static final SimpleDateFormat DATE_FORMATTER = new SimpleDateFormat(DATE_FORMAT);
 
     /**
@@ -22,6 +22,7 @@ public class DateUtil {
      * @throws IllegalValueException If the date string is not in the correct format.
      */
     public static Date parse(String date) throws IllegalValueException {
+        DATE_FORMATTER.setLenient(false);
         try {
             return DATE_FORMATTER.parse(date);
         } catch (ParseException e) {

--- a/src/main/java/seedu/address/logic/commands/DeleteLoanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteLoanCommand.java
@@ -1,10 +1,12 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LOAN_INDEX;
 
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Loan;
@@ -19,19 +21,19 @@ public class DeleteLoanCommand extends Command {
     public static final String COMMAND_WORD = "deleteloan";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Delete the specified loan index of the person who is identified"
+            + ": Delete the specified loan index of the person who is identified "
             + "by the index number. "
-            + "Parameters: INDEX (must be a positive integer), LOAN_INDEX (must be a positive integer)\n"
+            + "Parameters: INDEX "
+            + PREFIX_LOAN_INDEX + "LOAN_INDEX\n"
+            + "Both INDEX and LOAN_INDEX must be positive integers.\n"
             + "Example: " + COMMAND_WORD + " 1 " + "l/1";
-
-    public static final String MESSAGE_NOT_IMPLEMENTED_YET =
-            "Delete loan command not implemented yet";
     public static final String MESSAGE_ARGUMENTS = "Person number: %1$d, Loan Index: %2$d";
     public static final String MESSAGE_SUCCESS = "Loan deleted.\n"
             + "Person Name: %1$s\n"
             + "Loan: %2$s";
     public static final String MESSAGE_FAILURE_PERSON = "No person found for Person number: %1$d";
-    public static final String MESSAGE_FAILURE_LOAN = "No loan found for Loan number: %1$d for given person";
+    public static final String MESSAGE_FAILURE_LOAN = "No loan has been found "
+            + "for loan number: %1$d for %2$s";
     private final Index personIndex;
     private final Index loanIndex;
 
@@ -48,13 +50,14 @@ public class DeleteLoanCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         List<Person> lastShownList = model.getFilteredPersonList();
-        Person personToEdit = lastShownList.get(personIndex.getZeroBased());
-        if (personToEdit == null) {
-            throw new CommandException(String.format(MESSAGE_FAILURE_PERSON, personIndex.getOneBased()));
+        if (personIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
+        Person personToEdit = lastShownList.get(personIndex.getZeroBased());
         if (loanIndex.getZeroBased() >= personToEdit.getLoanRecords().size()) {
             // in reality, it's loan index outside of list range. We will be concerned about it later.
-            throw new CommandException(String.format(MESSAGE_FAILURE_LOAN, loanIndex.getOneBased()));
+            throw new CommandException(String.format(MESSAGE_FAILURE_LOAN, loanIndex.getOneBased(),
+                    personToEdit.getName()));
         }
         LoanRecords loanRecords = personToEdit.getLoanRecords();
         // delete specified loan number

--- a/src/main/java/seedu/address/logic/commands/LinkLoanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LinkLoanCommand.java
@@ -34,8 +34,8 @@ public class LinkLoanCommand extends Command {
             + "Example: " + COMMAND_WORD + " "
             + "5 "
             + PREFIX_VALUE + "500.00 "
-            + PREFIX_START_DATE + "15-02-2024 "
-            + PREFIX_RETURN_DATE + "21-04-2024";
+            + PREFIX_START_DATE + "2024-02-15 "
+            + PREFIX_RETURN_DATE + "2024-04-21";
 
     public static final String MESSAGE_SUCCESS = "New loan linked: %1$s";
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -3,14 +3,14 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.commons.util.DateUtil;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.commands.LinkLoanCommand.LinkLoanDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -135,21 +135,29 @@ public class ParserUtil {
     public static LinkLoanDescriptor parseLoan(String value, String startDate, String returnDate)
             throws ParseException {
         requireAllNonNull(value, startDate, returnDate);
+        String trimmedValue = value.trim();
+        String trimmedStartDate = startDate.trim();
+        String trimmedReturnDate = returnDate.trim();
+        float convertedValue;
+        Date convertedStartDate;
+        Date convertedReturnDate;
         try {
-            DateFormat formatter = new SimpleDateFormat("dd-MM-yyyy");
-            String trimmedValue = value.trim();
-            String trimmedStartDate = startDate.trim();
-            String trimmedReturnDate = returnDate.trim();
-            float convertedValue = Float.parseFloat(trimmedValue);
-            Date convertedStartDate = formatter.parse(trimmedStartDate);
-            Date convertedReturnDate = formatter.parse(trimmedReturnDate);
-            if (!Loan.isValidValue(convertedValue)
-                    || !Loan.isValidDates(convertedStartDate, convertedReturnDate)) {
-                throw new ParseException(Loan.MESSAGE_CONSTRAINTS);
-            }
-            return new LinkLoanDescriptor(convertedValue, convertedStartDate, convertedReturnDate);
-        } catch (java.text.ParseException p) {
+            convertedValue = Float.parseFloat(trimmedValue);
+            convertedStartDate = DateUtil.parse(trimmedStartDate);
+            convertedReturnDate = DateUtil.parse(trimmedReturnDate);
+        } catch (IllegalValueException i) {
+            // This is caught when the formatter is unable to parse the date correctly
+            throw new ParseException(Loan.DATE_CONSTRAINTS);
+        } catch (NumberFormatException n) {
+            // Ths is caught when the formatter is unable to parse the value correctly
+            throw new ParseException(Loan.VALUE_CONSTRAINTS);
+        }
+        if (!Loan.isValidValue(convertedValue)) {
+            throw new ParseException(Loan.VALUE_CONSTRAINTS);
+        }
+        if (!Loan.isValidDates(convertedStartDate, convertedReturnDate)) {
             throw new ParseException(Loan.DATE_CONSTRAINTS);
         }
+        return new LinkLoanDescriptor(convertedValue, convertedStartDate, convertedReturnDate);
     }
 }

--- a/src/main/java/seedu/address/model/person/Loan.java
+++ b/src/main/java/seedu/address/model/person/Loan.java
@@ -4,17 +4,18 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Date;
 
+import seedu.address.commons.util.DateUtil;
+
 /**
  * Represents a Loan in the address book.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
 public class Loan {
 
-    public static final String DATE_CONSTRAINTS = "Dates should be of the form dd-mm-yyyy";
+    public static final String DATE_CONSTRAINTS = "Dates should be of the form " + DateUtil.DATE_FORMAT
+            + " and the loan start date must be before the return date.";
 
-    public static final String MESSAGE_CONSTRAINTS = "Loans must be positive and have "
-                                                    + "a start date before the return date.";
-
+    public static final String VALUE_CONSTRAINTS = "Loan values must be a positive number.";
 
     private final int id;
     private final float value;

--- a/src/main/java/seedu/address/storage/JsonAdaptedLoan.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedLoan.java
@@ -46,10 +46,10 @@ public class JsonAdaptedLoan {
      */
     public Loan toModelType() throws IllegalValueException {
         if (!Loan.isValidValue(value)) {
-            throw new IllegalValueException(Loan.MESSAGE_CONSTRAINTS);
+            throw new IllegalValueException(Loan.VALUE_CONSTRAINTS);
         }
         if (!Loan.isValidDates(DateUtil.parse(startDate), DateUtil.parse(returnDate))) {
-            throw new IllegalValueException(Loan.MESSAGE_CONSTRAINTS);
+            throw new IllegalValueException(Loan.DATE_CONSTRAINTS);
         }
         return new Loan(id, value, DateUtil.parse(startDate), DateUtil.parse(returnDate));
     }


### PR DESCRIPTION
Fixes #50.

- Fixed a serious bug where `deleteloan` would throw an unchecked `IndexOutOfBounds` exception and cause the program to crash if the person number exceeded the number of people in the list.
- Fixed a bug where incorrectly formatted dates were accepted by the parser (`DateUtil`) and standardised handling of all dates to `yyyy-MM-dd` format
- Improved logic handling of invalid dates and invalid values, with each showing a different error message respectively after a `linkloan` command is executed.
- Multiple cosmetic changes to display of error messages for the `linkloan` and `deleteloan` commands (including showing which person has an invalid loan number for `deleteloan` when the loan number exceeds their number of loans)