### PR TITLE
Fixes #58 Improve loan id generation

### DIFF
--- a/src/main/java/seedu/address/model/person/Loan.java
+++ b/src/main/java/seedu/address/model/person/Loan.java
@@ -21,6 +21,7 @@ public class Loan {
     private final float value;
     private final Date startDate;
     private final Date returnDate;
+    private boolean isReturned;
 
     /**
      * Constructs a {@code Loan} with a given id.
@@ -36,6 +37,25 @@ public class Loan {
         this.value = value;
         this.startDate = startDate;
         this.returnDate = returnDate;
+        this.isReturned = false;
+    }
+
+    /**
+     * Constructs a {@code Loan} with a given id and return status.
+     *
+     * @param id A valid id.
+     * @param value A valid value.
+     * @param startDate A valid start date.
+     * @param returnDate A valid return date.
+     * @param isReturned A valid return status.
+     */
+    public Loan(int id, float value, Date startDate, Date returnDate, boolean isReturned) {
+        requireAllNonNull(id, value, startDate, returnDate, isReturned);
+        this.id = id;
+        this.value = value;
+        this.startDate = startDate;
+        this.returnDate = returnDate;
+        this.isReturned = isReturned;
     }
 
     /**
@@ -68,9 +88,31 @@ public class Loan {
         return returnDate;
     }
 
+    public boolean isReturned() {
+        return isReturned;
+    }
+
+    public boolean isActive() {
+        return !isReturned;
+    }
+
+    /**
+     * Marks the loan as returned.
+     */
+    public void markAsReturned() {
+        isReturned = true;
+    }
+
     @Override
     public String toString() {
-        return String.format("$%.2f, %s, %s", value, startDate, returnDate);
+        // return String.format("$%.2f, %s, %s", value, startDate, returnDate);
+        if (isReturned) {
+            return String.format("$%.2f, %s, %s (Returned)", value, DateUtil.format(startDate),
+                    DateUtil.format(returnDate));
+        } else {
+            return String.format("$%.2f, %s, %s", value, DateUtil.format(startDate),
+                    DateUtil.format(returnDate));
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Loan.java
+++ b/src/main/java/seedu/address/model/person/Loan.java
@@ -105,7 +105,6 @@ public class Loan {
 
     @Override
     public String toString() {
-        // return String.format("$%.2f, %s, %s", value, startDate, returnDate);
         if (isReturned) {
             return String.format("$%.2f, %s, %s (Returned)", value, DateUtil.format(startDate),
                     DateUtil.format(returnDate));

--- a/src/main/java/seedu/address/model/person/LoanRecords.java
+++ b/src/main/java/seedu/address/model/person/LoanRecords.java
@@ -4,6 +4,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 
@@ -18,26 +19,26 @@ import seedu.address.logic.commands.LinkLoanCommand.LinkLoanDescriptor;
 public class LoanRecords {
 
     private static final String DATE_MESSAGE_CONSTRAINTS = "Dates must be in the format dd-MM-yyyy.";
+    private static int nextLoanId = 1;
 
     private final List<Loan> loans;
-    private int nextLoanId;
-
     /**
      * Constructs a {@code LoanRecords}.
      */
     public LoanRecords() {
         loans = new ArrayList<>();
-        nextLoanId = 1;
     }
 
     /**
-     * Constructs a {@code LoanRecords} with a given id.
-     * @param nextLoanId A valid id.
+     * Constructs a {@code LoanRecords} with a given list of loans.
+     * @param loans A valid list of loans.
      */
-    public LoanRecords(List<Loan> loans, int nextLoanId) {
+    public LoanRecords(List<Loan> loans) {
         requireAllNonNull(loans);
         this.loans = loans;
-        this.nextLoanId = nextLoanId;
+        for (Loan loan : loans) {
+            nextLoanId = Math.max(nextLoanId, loan.getId() + 1);
+        }
     }
 
     /**
@@ -182,7 +183,16 @@ public class LoanRecords {
         }
 
         LoanRecords otherLoanRecords = (LoanRecords) other;
-        return this.nextLoanId == otherLoanRecords.nextLoanId;
+        // create hashset of ids of loans in this and other
+        HashSet<Integer> thisLoanIds = new HashSet<>();
+        HashSet<Integer> otherLoanIds = new HashSet<>();
+        for (Loan loan : loans) {
+            thisLoanIds.add(loan.getId());
+        }
+        for (Loan loan : otherLoanRecords.loans) {
+            otherLoanIds.add(loan.getId());
+        }
+        return thisLoanIds.equals(otherLoanIds);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/LoanRecords.java
+++ b/src/main/java/seedu/address/model/person/LoanRecords.java
@@ -104,6 +104,34 @@ public class LoanRecords {
         return loans.get(idx);
     }
 
+    public Loan getLoanById(int id) {
+        for (Loan loan : loans) {
+            if (loan.getId() == id) {
+                return loan;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Marks a loan as returned.
+     * @param idx A valid index.
+     */
+    public void markLoanAsReturned(int idx) {
+        loans.get(idx).markAsReturned();
+    }
+
+    /**
+     * Marks a loan as returned.
+     * @param id A valid id.
+     */
+    public void markLoanAsReturnedById(int id) {
+        Loan loan = getLoanById(id);
+        if (loan != null) {
+            loan.markAsReturned();
+        }
+    }
+
     /**
      * @return A list of loans.
      */

--- a/src/main/java/seedu/address/storage/JsonAdaptedLoan.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedLoan.java
@@ -16,17 +16,20 @@ public class JsonAdaptedLoan {
     private final String startDate;
     private final String returnDate;
     private final int id;
+    private boolean isReturned;
 
     /**
      * Constructs a {@code JsonAdaptedLoan} with the given loan details.
      */
     @JsonCreator
     public JsonAdaptedLoan(@JsonProperty("value") float value, @JsonProperty("startDate") String startDate,
-                           @JsonProperty("returnDate") String returnDate, @JsonProperty("id") int id) {
+                           @JsonProperty("returnDate") String returnDate, @JsonProperty("id") int id,
+                           @JsonProperty("isReturned") boolean isReturned) {
         this.value = value;
         this.startDate = startDate;
         this.returnDate = returnDate;
         this.id = id;
+        this.isReturned = isReturned;
     }
 
     /**
@@ -37,6 +40,7 @@ public class JsonAdaptedLoan {
         startDate = DateUtil.format(source.getStartDate());
         returnDate = DateUtil.format(source.getReturnDate());
         id = source.getId();
+        isReturned = source.isReturned();
     }
 
     /**
@@ -51,7 +55,7 @@ public class JsonAdaptedLoan {
         if (!Loan.isValidDates(DateUtil.parse(startDate), DateUtil.parse(returnDate))) {
             throw new IllegalValueException(Loan.DATE_CONSTRAINTS);
         }
-        return new Loan(id, value, DateUtil.parse(startDate), DateUtil.parse(returnDate));
+        return new Loan(id, value, DateUtil.parse(startDate), DateUtil.parse(returnDate), isReturned);
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedLoanRecords.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedLoanRecords.java
@@ -19,16 +19,13 @@ public class JsonAdaptedLoanRecords {
     public static final String MISSING_MESSAGE = "LoanRecords' loans field is missing!";
 
     private final List<JsonAdaptedLoan> loans;
-    private final int nextLoanId;
 
     /**
      * Constructs a {@code JsonAdaptedLoanRecords} with the given loan details.
      */
     @JsonCreator
-    public JsonAdaptedLoanRecords(@JsonProperty("loans") List<JsonAdaptedLoan> loans,
-                                    @JsonProperty("nextLoanId") int nextLoanId) {
+    public JsonAdaptedLoanRecords(@JsonProperty("loans") List<JsonAdaptedLoan> loans) {
         this.loans = loans;
-        this.nextLoanId = nextLoanId;
     }
 
     /**
@@ -39,11 +36,17 @@ public class JsonAdaptedLoanRecords {
             loans = source.getLoanList().stream()
                 .map(JsonAdaptedLoan::new)
                 .collect(Collectors.toList());
-            nextLoanId = source.getNextLoanId();
         } else {
             loans = null;
-            nextLoanId = 0;
         }
+    }
+
+    /**
+     * Factory method to create a new instance of JsonAdaptedLoanRecords
+     * to disambiguate the constructor for null values.
+     */
+    public static JsonAdaptedLoanRecords factory(LoanRecords source) {
+        return new JsonAdaptedLoanRecords(source);
     }
 
     /**
@@ -60,7 +63,7 @@ public class JsonAdaptedLoanRecords {
         for (JsonAdaptedLoan loan : loans) {
             loanList.add(loan.toModelType());
         }
-        LoanRecords loanRecords = new LoanRecords(loanList, nextLoanId);
+        LoanRecords loanRecords = new LoanRecords(loanList);
 
         return loanRecords;
     }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -23,7 +23,7 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
-    private static final JsonAdaptedLoanRecords INVALID_LOAN_RECORDS = new JsonAdaptedLoanRecords(null);
+    private static final JsonAdaptedLoanRecords INVALID_LOAN_RECORDS = JsonAdaptedLoanRecords.factory(null);
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();


### PR DESCRIPTION
Updates to `LoanRecords`:
- `nextLoanId` is now static
- `nextLoanId` is always one larger than the largest loan id found when loading the loans from storage

Updates to `JsonAdaptedLoanRecords`:
- No longer stores `nextLoanId`

Note that this generally has no impact on the rest of the program. It's just a technical debt that should be addressed.