### PR TITLE
Add target contact at the top of viewloan interface

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ViewLoanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewLoanCommand.java
@@ -40,6 +40,7 @@ public class ViewLoanCommand extends Command {
         }
 
         Person personToShowLoan = lastShownList.get(targetIndex.getZeroBased());
+        model.updateFilteredPersonList(person -> person.equals(personToShowLoan));
         LoanRecords loanRecords = personToShowLoan.getLoanRecords();
 
         // TODO model.updateLoanList or something

--- a/src/main/java/seedu/address/ui/LoanListPanel.java
+++ b/src/main/java/seedu/address/ui/LoanListPanel.java
@@ -9,6 +9,7 @@ import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Loan;
+import seedu.address.model.person.Person;
 
 /**
  * Panel containing the list of persons.
@@ -20,13 +21,18 @@ public class LoanListPanel extends UiPart<Region> {
     @FXML
     private ListView<Loan> loanListView;
 
+    @FXML
+    private ListView<Person> personListView;
+
     /**
      * Creates a {@code PersonListPanel} with the given {@code ObservableList}.
      */
-    public LoanListPanel(ObservableList<Loan> loanList) {
+    public LoanListPanel(ObservableList<Loan> loanList, ObservableList<Person> personList) {
         super(FXML);
         loanListView.setItems(loanList);
         loanListView.setCellFactory(listView -> new LoanListViewCell());
+        personListView.setItems(personList);
+        personListView.setCellFactory(listView -> new PersonListViewCell());
     }
 
     /**
@@ -43,6 +49,20 @@ public class LoanListPanel extends UiPart<Region> {
                 setText(null);
             } else {
                 setGraphic(new LoanCard(loan, getIndex() + 1).getRoot());
+            }
+        }
+    }
+
+    class PersonListViewCell extends ListCell<Person> {
+        @Override
+        protected void updateItem(Person person, boolean empty) {
+            super.updateItem(person, empty);
+
+            if (empty || person == null) {
+                setGraphic(null);
+                setText(null);
+            } else {
+                setGraphic(new PersonCard(person, getIndex() + 1).getRoot());
             }
         }
     }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -127,7 +127,7 @@ public class MainWindow extends UiPart<Stage> {
         // By default, the person list panel is shown
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
-        loanListPanel = new LoanListPanel(logic.getLoanList());
+        loanListPanel = new LoanListPanel(logic.getLoanList(), logic.getFilteredPersonList());
 
         this.isLoansTab.addListener((observable, oldValue, newValue) -> {
             if (newValue) {

--- a/src/main/resources/view/LoanListPanel.fxml
+++ b/src/main/resources/view/LoanListPanel.fxml
@@ -3,6 +3,7 @@
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" spacing="0">
+    <ListView fx:id="personListView" maxHeight="290"/>
     <ListView fx:id="loanListView" VBox.vgrow="ALWAYS"/>
 </VBox>


### PR DESCRIPTION
Fixes #56 

On `viewloan` command, the target contact is displayed at the top of the list
<img width="735" alt="Screenshot 2024-03-19 at 8 35 55 PM" src="https://github.com/AY2324S2-CS2103T-W13-1/tp/assets/117426083/2a0a5d43-1592-457a-9930-dadd50bdfa85">

### Potential changes for the future

- Code duplication between `PersonListPanel` and `LoanListPanel` can be reduced in the future
- Dimension of PersonCard at the top of viewloan interface is hard-coded and behaviour may change if more details were to be added (if some information takes more than 1 row for example, the scroll wheel will appear on the right for the PersonCard as well)