### PR TITLE
Mark loan command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteLoanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteLoanCommand.java
@@ -67,8 +67,7 @@ public class DeleteLoanCommand extends Command {
     }
 
     /**
-     * Generates a command execution success message based on whether
-     * the remark is added to or removed from
+     * Generates a command execution success message after loan is deleted from the
      * {@code personToEdit}.
      */
     private String generateSuccessMessage(Name personName, Loan removedLoan) {

--- a/src/main/java/seedu/address/logic/commands/MarkLoanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkLoanCommand.java
@@ -1,0 +1,27 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LOAN_INDEX;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+
+
+/**
+ * Marks a loan as paid.
+ */
+public class MarkLoanCommand extends Command {
+    public static final String COMMAND_WORD = "markloan";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Marks the loan specified as paid.\n"
+            + "Parameters: INDEX "
+            + PREFIX_LOAN_INDEX + "LOAN_INDEX\n"
+            + "Both INDEX and LOAN_INDEX must be positive integers.\n"
+            + "Example: " + COMMAND_WORD + " 1 " + "l/2\n"
+            + "This marks the loan of loan index 2 of the person at index 1 as paid.";
+    public static final String MESSAGE_NOT_IMPLEMENTED_YET = "Remark command not implemented yet";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        throw new CommandException(MESSAGE_NOT_IMPLEMENTED_YET);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/MarkLoanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkLoanCommand.java
@@ -1,7 +1,9 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOAN_INDEX;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 
@@ -19,6 +21,19 @@ public class MarkLoanCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 " + "l/2\n"
             + "This marks the loan of loan index 2 of the person at index 1 as paid.";
     public static final String MESSAGE_NOT_IMPLEMENTED_YET = "Remark command not implemented yet";
+    private final Index personIndex;
+    private final Index loanIndex;
+
+    /**
+     * Creates a MarkLoanCommand to delete the specified loan.
+     * @param personIndex
+     * @param loanIndex
+     */
+    public MarkLoanCommand(Index personIndex, Index loanIndex) {
+        requireAllNonNull(personIndex, loanIndex);
+        this.personIndex = personIndex;
+        this.loanIndex = loanIndex;
+    }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {

--- a/src/main/java/seedu/address/logic/commands/MarkLoanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkLoanCommand.java
@@ -1,12 +1,19 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.commands.DeleteLoanCommand.MESSAGE_FAILURE_PERSON;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOAN_INDEX;
 
+import java.util.List;
+
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-
+import seedu.address.model.person.Loan;
+import seedu.address.model.person.LoanRecords;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
 
 
 /**
@@ -21,6 +28,12 @@ public class MarkLoanCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 " + "l/2\n"
             + "This marks the loan of loan index 2 of the person at index 1 as paid.";
     public static final String MESSAGE_NOT_IMPLEMENTED_YET = "Remark command not implemented yet";
+    public static final String MESSAGE_SUCCESS = "Loan marked.\n"
+            + "Person Name: %1$s\n"
+            + "Loan: %2$s";
+    public static final String MESSAGE_FAILURE_PERSON = "No person found for Person number: %1$d";
+    public static final String MESSAGE_FAILURE_LOAN = "No loan has been found "
+            + "for loan number: %1$d for %2$s";
     private final Index personIndex;
     private final Index loanIndex;
 
@@ -37,6 +50,44 @@ public class MarkLoanCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        throw new CommandException(MESSAGE_NOT_IMPLEMENTED_YET);
+        List<Person> lastShownList = model.getFilteredPersonList();
+        Person personToEdit;
+        LoanRecords loanRecords;
+        try {
+            personToEdit = lastShownList.get(personIndex.getZeroBased());
+        } catch (IndexOutOfBoundsException i) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+        try {
+            loanRecords = personToEdit.getLoanRecords();
+            loanRecords.markLoan(loanIndex.getZeroBased());
+        } catch (IndexOutOfBoundsException i) {
+            throw new CommandException(String.format(MESSAGE_FAILURE_LOAN, loanIndex.getOneBased(),
+                    personToEdit.getName()));
+        }
+        return new CommandResult(generateSuccessMessage(personToEdit.getName(),
+                loanRecords.getLoan(loanIndex.getZeroBased())));
+    }
+
+    /**
+     * Generates a command execution success message after loan is deleted from the
+     * {@code personToEdit}.
+     */
+    private String generateSuccessMessage(Name personName, Loan markedLoan) {
+        return String.format(MESSAGE_SUCCESS, personName, markedLoan);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        // instanceof handles nulls
+        if (!(other instanceof MarkLoanCommand)) {
+            return false;
+        }
+        MarkLoanCommand e = (MarkLoanCommand) other;
+        return personIndex.equals(e.personIndex)
+                && loanIndex.equals(e.loanIndex);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.LinkLoanCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.MarkLoanCommand;
 import seedu.address.logic.commands.ViewLoanCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -88,6 +89,9 @@ public class AddressBookParser {
 
         case ViewLoanCommand.COMMAND_WORD:
             return new ViewLoanCommandParser().parse(arguments);
+
+        case MarkLoanCommand.COMMAND_WORD:
+            return new MarkLoanCommand();
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -91,7 +91,7 @@ public class AddressBookParser {
             return new ViewLoanCommandParser().parse(arguments);
 
         case MarkLoanCommand.COMMAND_WORD:
-            return new MarkLoanCommand();
+            return new MarkLoanCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/MarkLoanCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MarkLoanCommandParser.java
@@ -1,0 +1,47 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LOAN_INDEX;
+
+import java.util.stream.Stream;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.MarkLoanCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new MarkLoanCommand object.
+ */
+public class MarkLoanCommandParser implements Parser<MarkLoanCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the MarkLoanCommand
+     * and returns a MarkLoanCommand object for execution.
+     */
+    public MarkLoanCommand parse(String args) throws ParseException {
+        requireAllNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_LOAN_INDEX);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_LOAN_INDEX)
+                || argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkLoanCommand.MESSAGE_USAGE));
+        }
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_LOAN_INDEX);
+        try {
+            Index personIndex = ParserUtil.parseIndex(argMultimap.getPreamble());
+            Index loanIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_LOAN_INDEX).get());
+            return new MarkLoanCommand(personIndex, loanIndex);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkLoanCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/model/person/Loan.java
+++ b/src/main/java/seedu/address/model/person/Loan.java
@@ -112,6 +112,13 @@ public class Loan {
         isReturned = true;
     }
 
+    /**
+     * Marks the loan as not returned.
+     */
+    public void markAsNotReturned() {
+        isReturned = false;
+    }
+
     @Override
     public String toString() {
         if (isReturned) {

--- a/src/main/java/seedu/address/model/person/LoanRecords.java
+++ b/src/main/java/seedu/address/model/person/LoanRecords.java
@@ -155,6 +155,20 @@ public class LoanRecords {
     }
 
     /**
+     * Marks a loan of the specified index as returned.
+     */
+    public void markLoan(int idx) {
+        loans.get(idx).markAsReturned();
+    }
+
+    /**
+     * Marks a loan of the specified index as not returned.
+     */
+    public void unmarkLoan(int idx) {
+        loans.get(idx).markAsNotReturned();
+    }
+
+    /**
      * @return The number of loans in the list.
      */
     public int size() {

--- a/src/test/java/seedu/address/logic/commands/DeleteLoanCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteLoanCommandTest.java
@@ -1,0 +1,4 @@
+package seedu.address.logic.commands;
+
+public class DeleteLoanCommandTest {
+}

--- a/src/test/java/seedu/address/logic/commands/MarkLoanCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkLoanCommandTest.java
@@ -20,7 +20,6 @@ public class MarkLoanCommandTest {
 
     @Test
     public void execute() {
-        assertCommandFailure(new MarkLoanCommand(Index.fromZeroBased(0), Index.fromZeroBased(0)),
-                model, MESSAGE_NOT_IMPLEMENTED_YET);
+        return;
     }
 }

--- a/src/test/java/seedu/address/logic/commands/MarkLoanCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkLoanCommandTest.java
@@ -1,0 +1,24 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.MarkLoanCommand.MESSAGE_NOT_IMPLEMENTED_YET;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for MarkLoanCommand.
+ */
+public class MarkLoanCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute() {
+        assertCommandFailure(new MarkLoanCommand(), model, MESSAGE_NOT_IMPLEMENTED_YET);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/MarkLoanCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkLoanCommandTest.java
@@ -6,6 +6,7 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -19,6 +20,7 @@ public class MarkLoanCommandTest {
 
     @Test
     public void execute() {
-        assertCommandFailure(new MarkLoanCommand(), model, MESSAGE_NOT_IMPLEMENTED_YET);
+        assertCommandFailure(new MarkLoanCommand(Index.fromZeroBased(0), Index.fromZeroBased(0)),
+                model, MESSAGE_NOT_IMPLEMENTED_YET);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/MarkLoanCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkLoanCommandTest.java
@@ -1,25 +1,40 @@
 package seedu.address.logic.commands;
 
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.address.logic.commands.MarkLoanCommand.MESSAGE_NOT_IMPLEMENTED_YET;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersonsWithLoans.LOAN_RECORDS;
+import static seedu.address.testutil.TypicalPersonsWithLoans.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.commons.core.index.Index;
+import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.LoanRecords;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for MarkLoanCommand.
  */
 public class MarkLoanCommandTest {
-
+    private static LoanRecords LOAN_RECORDS_STUB = LOAN_RECORDS;
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-
     @Test
-    public void execute() {
-        return;
+    public void execute_markLoanSuccess() {
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        LOAN_RECORDS_STUB.markLoan(0);
+        Person editedPerson = new PersonBuilder(firstPerson).withLoanRecords(LOAN_RECORDS_STUB).build();
+
+        MarkLoanCommand markLoanCommand = new MarkLoanCommand(INDEX_FIRST_PERSON, INDEX_FIRST_PERSON);
+
+        String expectedMessage = String.format(MarkLoanCommand.MESSAGE_SUCCESS, editedPerson.getName(),
+                LOAN_RECORDS_STUB.getLoan(0));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(firstPerson, editedPerson);
+
+        assertCommandSuccess(markLoanCommand, model, expectedMessage, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -25,6 +25,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.MarkLoanCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
@@ -97,6 +98,12 @@ public class AddressBookParserTest {
                 + " 1 " + PREFIX_LOAN_INDEX + "2");
         DeleteLoanCommand test = new DeleteLoanCommand(INDEX_FIRST_PERSON, Index.fromOneBased(2));
         assertEquals(test, ddlc);
+    }
+
+    @Test
+    public void parseCommand_markLoan() throws Exception {
+        assertTrue(parser.parseCommand(MarkLoanCommand.COMMAND_WORD) instanceof MarkLoanCommand);
+        assertTrue(parser.parseCommand(MarkLoanCommand.COMMAND_WORD + " 3") instanceof MarkLoanCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -102,7 +102,10 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_markLoan() throws Exception {
-        assertTrue(parser.parseCommand(MarkLoanCommand.COMMAND_WORD + " 1 l/2") instanceof MarkLoanCommand);
+        MarkLoanCommand markLoanCommand = (MarkLoanCommand) parser.parseCommand(MarkLoanCommand.COMMAND_WORD
+                + " 1 " + PREFIX_LOAN_INDEX + "2");
+        MarkLoanCommand test = new MarkLoanCommand(INDEX_FIRST_PERSON, Index.fromOneBased(2));
+        assertEquals(test, markLoanCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -102,8 +102,7 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_markLoan() throws Exception {
-        assertTrue(parser.parseCommand(MarkLoanCommand.COMMAND_WORD) instanceof MarkLoanCommand);
-        assertTrue(parser.parseCommand(MarkLoanCommand.COMMAND_WORD + " 3") instanceof MarkLoanCommand);
+        assertTrue(parser.parseCommand(MarkLoanCommand.COMMAND_WORD + " 1 l/2") instanceof MarkLoanCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TypicalPersonsWithLoans.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersonsWithLoans.java
@@ -15,17 +15,21 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.commons.util.DateUtil;
 import seedu.address.model.AddressBook;
+import seedu.address.model.person.LoanRecords;
 import seedu.address.model.person.Person;
 
 /**
  * A utility class containing a list of {@code Person} objects to be used in tests.
  */
-public class TypicalPersons {
+public class TypicalPersonsWithLoans {
+    public static final LoanRecords LOAN_RECORDS = loanRecords();
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
             .withPhone("94351253")
-            .withTags("friends").build();
+            .withTags("friends").withLoanRecords(LOAN_RECORDS).build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432")
@@ -56,7 +60,22 @@ public class TypicalPersons {
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
 
-    private TypicalPersons() {} // prevents instantiation
+    private TypicalPersonsWithLoans() {} // prevents instantiation
+
+    /**
+     * Returns an {@code LoanRecords} stub with some typical loans.
+     */
+    public static LoanRecords loanRecords() {
+        LoanRecords loanRecords = new LoanRecords();
+        try {
+            loanRecords.addLoan(100F, DateUtil.parse("2020-01-01"), DateUtil.parse("2020-01-13"));
+            loanRecords.addLoan(200F, DateUtil.parse("2020-02-01"), DateUtil.parse("2020-02-13"));
+            loanRecords.addLoan(300F, DateUtil.parse("2020-02-13"), DateUtil.parse("2020-02-14"));
+        } catch (IllegalValueException e) {
+            e.printStackTrace();
+        }
+        return loanRecords;
+    }
 
     /**
      * Returns an {@code AddressBook} with all the typical persons.


### PR DESCRIPTION
Implemented Mark Loan Command. 

Created tests for MarkLoanCommand class. Added a TypicalPersonsWithLoans.class to ease with testing, while preserving existing tests. Also made minor edits to Loan and LoanRecord classes.

Usage: `markloan INDEX l/LOAN_INDEX`
example: `markloan 1 l/2`

Fixes #32 