### PR TITLE
Implement editloan command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditLoanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditLoanCommand.java
@@ -1,0 +1,200 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RETURN_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_VALUE;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.commands.LinkLoanCommand.LinkLoanDescriptor;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Loan;
+import seedu.address.model.person.Person;
+
+/**
+ * Edits a loan of a person in the address book.
+ */
+public class EditLoanCommand extends Command {
+
+    public static final String COMMAND_WORD = "editloan";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the loan specified "
+            + "by its loan index number, possibly changing "
+            + "its value, start date and/or return date. "
+            + "At least one field must be changed.\n"
+            + "Parameters: "
+            + "LOAN_INDEX "
+            + "[" + PREFIX_VALUE + "VALUE] "
+            + "[" + PREFIX_START_DATE + "START_DATE] "
+            + "[" + PREFIX_RETURN_DATE + "RETURN_DATE]\n"
+            + "Example: " + COMMAND_WORD + " "
+            + "5 "
+            + PREFIX_VALUE + "500.00 "
+            + PREFIX_START_DATE + "2024-02-15 "
+            + PREFIX_RETURN_DATE + "2024-04-21\n"
+            + "This edits the loan at loan index 5 "
+            + "to reflect a value of $500, "
+            + "a start date of 15 Feb 2024 "
+            + "and an end date of 21 April 2024.";
+
+    public static final String MESSAGE_SUCCESS = "Loan successfully edited: %1$s";
+
+    public static final String MESSAGE_FAILURE_LOAN = "No loan has been found "
+            + "for loan number: %1$d";
+
+    private final EditLoanDescriptor editedDetails;
+
+    private final Index loanIndex;
+
+    /**
+     * @param editedDetails New value(s) of the edited field(s) of the loan, as an EditLoanDescriptor
+     * @param loanIndex Index of the loan to be edited
+     */
+    public EditLoanCommand(EditLoanDescriptor editedDetails, Index loanIndex) {
+        requireAllNonNull(editedDetails, loanIndex);
+        this.editedDetails = editedDetails;
+        this.loanIndex = loanIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Loan> lastShownList = model.getSortedLoanList();
+        assert lastShownList != null;
+
+        if (loanIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(String.format(MESSAGE_FAILURE_LOAN, loanIndex.getOneBased()));
+        }
+
+        Loan loanToEdit = lastShownList.get(loanIndex.getZeroBased());
+        Person linkedPerson = loanToEdit.getAssignee();
+        LinkLoanDescriptor updatedLoanDetails = generateEditedLoanDetails(loanToEdit, editedDetails);
+        model.deleteLoan(loanToEdit);
+        Loan editedLoan = model.addLoan(updatedLoanDetails, linkedPerson);
+
+        return new CommandResult(generateSuccessMessage(editedLoan), false, false, true);
+    }
+
+    /**
+     * Generates a command execution success message after loan is edited.
+     */
+    private String generateSuccessMessage(Loan editedLoan) {
+        return String.format(MESSAGE_SUCCESS, editedLoan);
+    }
+
+    private LinkLoanDescriptor generateEditedLoanDetails(Loan loanToEdit, EditLoanDescriptor editedDetails)
+            throws CommandException {
+        float newValue = editedDetails.getValue().orElse(loanToEdit.getValue());
+        Date newStartDate = editedDetails.getStartDate().orElse(loanToEdit.getStartDate());
+        Date newReturnDate = editedDetails.getReturnDate().orElse(loanToEdit.getReturnDate());
+        requireAllNonNull(newValue, newStartDate, newReturnDate);
+        if (!Loan.isValidDates(newStartDate, newReturnDate)) {
+            throw new CommandException(Loan.DATE_CONSTRAINTS);
+        }
+        return new LinkLoanDescriptor(newValue, newStartDate, newReturnDate);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditLoanCommand)) {
+            return false;
+        }
+
+        EditLoanCommand otherEditLoanCommand = (EditLoanCommand) other;
+        return editedDetails.equals(otherEditLoanCommand.editedDetails)
+                && loanIndex.equals(otherEditLoanCommand.loanIndex);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("loanIndex", loanIndex)
+                .add("editedDetails", editedDetails)
+                .toString();
+    }
+
+    /**
+     * Stores the details of the loan that is edited.
+     */
+    public static class EditLoanDescriptor {
+        private Float value = null;
+        private Date startDate = null;
+        private Date returnDate = null;
+
+        /**
+         * Creates an instance of this EditLoanDescriptor with empty fields.
+         */
+        public EditLoanDescriptor() {}
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(value, startDate, returnDate);
+        }
+
+        public void setValue(float value) {
+            this.value = value;
+        }
+
+        public Optional<Float> getValue() {
+            return Optional.ofNullable(value);
+        }
+
+        public void setStartDate(Date startDate) {
+            this.startDate = startDate;
+        }
+
+        public Optional<Date> getStartDate() {
+            return Optional.ofNullable(startDate);
+        }
+
+        public void setReturnDate(Date returnDate) {
+            this.returnDate = returnDate;
+        }
+
+        public Optional<Date> getReturnDate() {
+            return Optional.ofNullable(returnDate);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof EditLoanDescriptor)) {
+                return false;
+            }
+
+            EditLoanDescriptor otherEditLoanDescriptor = (EditLoanDescriptor) other;
+            return Objects.equals(value, otherEditLoanDescriptor.value)
+                    && Objects.equals(getStartDate(), otherEditLoanDescriptor.getStartDate())
+                    && Objects.equals(getReturnDate(), otherEditLoanDescriptor.getReturnDate());
+        }
+
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this)
+                    .add("value", value)
+                    .add("startDate", startDate)
+                    .add("returnDate", returnDate)
+                    .toString();
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -15,6 +15,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.DeleteLoanCommand;
 import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.EditLoanCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
@@ -99,6 +100,9 @@ public class AddressBookParser {
 
         case AnalyticsCommand.COMMAND_WORD:
             return new AnalyticsCommandParser().parse(arguments);
+
+        case EditLoanCommand.COMMAND_WORD:
+            return new EditLoanCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/EditLoanCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditLoanCommandParser.java
@@ -58,7 +58,7 @@ public class EditLoanCommandParser implements Parser<EditLoanCommand> {
     }
 
     /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * Returns true if all the prefixes contain empty {@code Optional} values in the given
      * {@code ArgumentMultimap}.
      */
     private static boolean arePrefixesEmpty(ArgumentMultimap argumentMultimap, Prefix... prefixes) {

--- a/src/main/java/seedu/address/logic/parser/EditLoanCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditLoanCommandParser.java
@@ -1,0 +1,67 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RETURN_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_VALUE;
+
+import java.util.stream.Stream;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EditLoanCommand;
+import seedu.address.logic.commands.EditLoanCommand.EditLoanDescriptor;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new EditLoanCommand object
+ */
+public class EditLoanCommandParser implements Parser<EditLoanCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the EditCommand
+     * and returns an EditLoanCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public EditLoanCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_VALUE, PREFIX_START_DATE, PREFIX_RETURN_DATE);
+
+        if (arePrefixesEmpty(argMultimap, PREFIX_VALUE, PREFIX_START_DATE, PREFIX_RETURN_DATE)
+                || argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditLoanCommand.MESSAGE_USAGE));
+        }
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditLoanCommand.MESSAGE_USAGE), pe);
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_VALUE, PREFIX_START_DATE, PREFIX_RETURN_DATE);
+
+        EditLoanDescriptor editLoanDescriptor = new EditLoanDescriptor();
+
+        if (argMultimap.getValue(PREFIX_VALUE).isPresent()) {
+            editLoanDescriptor.setValue(ParserUtil.parseValue(argMultimap.getValue(PREFIX_VALUE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_START_DATE).isPresent()) {
+            editLoanDescriptor.setStartDate(ParserUtil.parseDate(argMultimap.getValue(PREFIX_START_DATE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_RETURN_DATE).isPresent()) {
+            editLoanDescriptor.setReturnDate(ParserUtil.parseDate(argMultimap.getValue(PREFIX_RETURN_DATE).get()));
+        }
+
+        return new EditLoanCommand(editLoanDescriptor, index);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesEmpty(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isEmpty());
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -160,4 +160,36 @@ public class ParserUtil {
         }
         return new LinkLoanDescriptor(convertedValue, convertedStartDate, convertedReturnDate);
     }
+
+    /**
+     * Parses {@code String value} into a {@code float}.
+     */
+    public static float parseValue(String value) throws ParseException {
+        requireNonNull(value);
+        String trimmedValue = value.trim();
+        float convertedValue;
+        try {
+            convertedValue = Float.parseFloat(trimmedValue);
+        } catch (NumberFormatException n) {
+            // Ths is caught when the formatter is unable to parse the value correctly
+            throw new ParseException(Loan.VALUE_CONSTRAINTS);
+        }
+        return convertedValue;
+    }
+
+    /**
+     * Parses {@code String date} into a {@code Date}.
+     */
+    public static Date parseDate(String date) throws ParseException {
+        requireNonNull(date);
+        String trimmedDate = date.trim();
+        Date convertedDate;
+        try {
+            convertedDate = DateUtil.parse(trimmedDate);
+        } catch (IllegalValueException i) {
+            // This is caught when the formatter is unable to parse the date correctly
+            throw new ParseException(Loan.DATE_CONSTRAINTS);
+        }
+        return convertedDate;
+    }
 }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -129,8 +129,8 @@ public class AddressBook implements ReadOnlyAddressBook {
         loans.addLoan(l);
     }
 
-    public void addLoan(LinkLoanCommand.LinkLoanDescriptor loanDescription, Person assignee) {
-        loans.addLoan(loanDescription, assignee);
+    public Loan addLoan(LinkLoanCommand.LinkLoanDescriptor loanDescription, Person assignee) {
+        return loans.addLoan(loanDescription, assignee);
     }
 
     public void markLoan(Loan loanToMark) {

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -112,7 +112,7 @@ public interface Model {
      */
     void addLoan(Loan loan);
 
-    void addLoan(LinkLoanCommand.LinkLoanDescriptor loanDescription, Person assignee);
+    Loan addLoan(LinkLoanCommand.LinkLoanDescriptor loanDescription, Person assignee);
 
     /**
      * Returns an unmodifiable view of the filtered person list

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -140,8 +140,8 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void addLoan(LinkLoanCommand.LinkLoanDescriptor loanDescription, Person assignee) {
-        addressBook.addLoan(loanDescription, assignee);
+    public Loan addLoan(LinkLoanCommand.LinkLoanDescriptor loanDescription, Person assignee) {
+        return addressBook.addLoan(loanDescription, assignee);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/UniqueLoanList.java
+++ b/src/main/java/seedu/address/model/person/UniqueLoanList.java
@@ -54,20 +54,21 @@ public class UniqueLoanList implements Iterable<Loan> {
      * @param startDate A valid start date.
      * @param returnDate A valid return date.
      */
-    public void addLoan(float value, Date startDate, Date returnDate, Person assignee) {
+    public Loan addLoan(float value, Date startDate, Date returnDate, Person assignee) {
         Loan loan = new Loan(nextLoanId, value, startDate, returnDate, assignee);
         addLoan(loan);
+        return loan;
     }
 
     /**
      * Adds a loan to the list of loans.
      * @param loanDescription A valid LinkLoanDescriptor, which contains details about the loan to be added.
      */
-    public void addLoan(LinkLoanDescriptor loanDescription, Person assignee) {
+    public Loan addLoan(LinkLoanDescriptor loanDescription, Person assignee) {
         float value = loanDescription.getValue();
         Date startDate = loanDescription.getStartDate();
         Date returnDate = loanDescription.getReturnDate();
-        addLoan(value, startDate, returnDate, assignee);
+        return addLoan(value, startDate, returnDate, assignee);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -208,7 +208,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void addLoan(LinkLoanCommand.LinkLoanDescriptor loanDescription, Person assignee) {
+        public Loan addLoan(LinkLoanCommand.LinkLoanDescriptor loanDescription, Person assignee) {
             throw new AssertionError("This method should not be called.");
         }
 


### PR DESCRIPTION
Fixes #92 and #93.

Command to link loan is of the form `editloan INDEX [v/VALUE] [s/START_DATE] [r/RETURN_DATE]`.
Examples:
- `editloan 5 v/500.00 s/2024-02-15 r/2024-04-21`
- `editloan 17 s/2025-01-03`

In addition, `model.addLoan` will now return the loan after it has been added.