### PR TITLE
Implement Analytics GUI (Tab switching)

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -3,12 +3,14 @@ package seedu.address.logic;
 import java.nio.file.Path;
 
 import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ObjectProperty;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.person.Analytics;
 import seedu.address.model.person.Loan;
 import seedu.address.model.person.Person;
 
@@ -58,4 +60,6 @@ public interface Logic {
     void setIsLoansTab(boolean isLoansTab);
 
     BooleanProperty getIsLoansTab();
+
+    ObjectProperty<Analytics> getAnalytics();
 }

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -61,5 +61,11 @@ public interface Logic {
 
     BooleanProperty getIsLoansTab();
 
+    void setIsAnalyticsTab(boolean isAnalyticsTab);
+
+    BooleanProperty getIsAnalyticsTab();
+
+    void setToPersonTab();
+
     ObjectProperty<Analytics> getAnalytics();
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import java.util.logging.Logger;
 
 import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ObjectProperty;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
@@ -16,6 +17,7 @@ import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.person.Analytics;
 import seedu.address.model.person.Loan;
 import seedu.address.model.person.Person;
 import seedu.address.storage.Storage;
@@ -101,5 +103,10 @@ public class LogicManager implements Logic {
     @Override
     public BooleanProperty getIsLoansTab() {
         return model.getIsLoansTab();
+    }
+
+    @Override
+    public ObjectProperty<Analytics> getAnalytics() {
+        return model.getAnalytics();
     }
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -109,4 +109,19 @@ public class LogicManager implements Logic {
     public ObjectProperty<Analytics> getAnalytics() {
         return model.getAnalytics();
     }
+
+    @Override
+    public BooleanProperty getIsAnalyticsTab() {
+        return model.getIsAnalyticsTab();
+    }
+
+    @Override
+    public void setIsAnalyticsTab(boolean isAnalyticsTab) {
+        model.setIsAnalyticsTab(isAnalyticsTab);
+    }
+
+    @Override
+    public void setToPersonTab() {
+        model.setToPersonTab();
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/AnalyticsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AnalyticsCommand.java
@@ -39,7 +39,8 @@ public class AnalyticsCommand extends Command {
         Analytics targetAnalytics = Analytics.getAnalytics(model.getSortedLoanList());
         // TODO: Implement analytics GUI display logic
         model.setAnalytics(targetAnalytics);
-        return new CommandResult(MESSAGE_SUCCESS + model.getAnalytics().getValue(), false, false, true);
+        return new CommandResult(MESSAGE_SUCCESS + model.getAnalytics().getValue(),
+                false, false, false);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AnalyticsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AnalyticsCommand.java
@@ -39,6 +39,7 @@ public class AnalyticsCommand extends Command {
         Analytics targetAnalytics = Analytics.getAnalytics(model.getSortedLoanList());
         // TODO: Implement analytics GUI display logic
         model.setAnalytics(targetAnalytics);
+        model.setIsAnalyticsTab(true);
         return new CommandResult(MESSAGE_SUCCESS + model.getAnalytics().getValue(),
                 false, false, false);
     }

--- a/src/main/java/seedu/address/logic/commands/AnalyticsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AnalyticsCommand.java
@@ -38,8 +38,8 @@ public class AnalyticsCommand extends Command {
         model.updateFilteredLoanList(loan -> loan.isAssignedTo(targetPerson) && loan.isActive());
         Analytics targetAnalytics = Analytics.getAnalytics(model.getSortedLoanList());
         // TODO: Implement analytics GUI display logic
-
-        return new CommandResult(MESSAGE_SUCCESS + targetAnalytics, false, false, true);
+        model.setAnalytics(targetAnalytics);
+        return new CommandResult(MESSAGE_SUCCESS + model.getAnalytics().getValue(), false, false, true);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AnalyticsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AnalyticsCommand.java
@@ -36,8 +36,9 @@ public class AnalyticsCommand extends Command {
 
         Person targetPerson = lastShownList.get(targetIndex.getZeroBased());
         model.updateFilteredLoanList(loan -> loan.isAssignedTo(targetPerson) && loan.isActive());
-        Analytics targetAnalytics = Analytics.getAnalytics(model.getUniqueLoanList());
+        Analytics targetAnalytics = Analytics.getAnalytics(model.getSortedLoanList());
         // TODO: Implement analytics GUI display logic
+
         return new CommandResult(MESSAGE_SUCCESS + targetAnalytics, false, false, true);
     }
 

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -18,6 +18,7 @@ public class ClearCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setAddressBook(new AddressBook());
+        model.setToPersonTab();
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -30,6 +30,7 @@ public class FindCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
+        model.setToPersonTab();
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -19,6 +19,7 @@ public class ListCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.setToPersonTab();
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,9 +5,11 @@ import java.util.List;
 import java.util.function.Predicate;
 
 import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ObjectProperty;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.LinkLoanCommand;
+import seedu.address.model.person.Analytics;
 import seedu.address.model.person.Loan;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniqueLoanList;
@@ -143,5 +145,7 @@ public interface Model {
 
     void markLoan(Loan loanToMark);
 
-    UniqueLoanList getUniqueLoanList();
+    void setAnalytics(Analytics analytics);
+
+    ObjectProperty<Analytics> getAnalytics();
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -12,7 +12,6 @@ import seedu.address.logic.commands.LinkLoanCommand;
 import seedu.address.model.person.Analytics;
 import seedu.address.model.person.Loan;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.UniqueLoanList;
 
 /**
  * The API of the Model component.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -147,6 +147,8 @@ public interface Model {
 
     void setIsAnalyticsTab(Boolean isAnalyticsTab);
 
+    void setToPersonTab();
+
     void markLoan(Loan loanToMark);
 
     void setAnalytics(Analytics analytics);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -143,9 +143,15 @@ public interface Model {
 
     void setIsLoansTab(Boolean isLoansTab);
 
+    BooleanProperty getIsAnalyticsTab();
+
+    void setIsAnalyticsTab(Boolean isAnalyticsTab);
+
     void markLoan(Loan loanToMark);
 
     void setAnalytics(Analytics analytics);
 
     ObjectProperty<Analytics> getAnalytics();
+
+
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -21,7 +21,6 @@ import seedu.address.logic.commands.LinkLoanCommand;
 import seedu.address.model.person.Analytics;
 import seedu.address.model.person.Loan;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.UniqueLoanList;
 
 /**
  * Represents the in-memory model of the address book data.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -35,6 +35,7 @@ public class ModelManager implements Model {
     private final FilteredList<Loan> filteredLoans;
     private final SortedList<Loan> sortedLoans;
     private final BooleanProperty isLoansTab = new SimpleBooleanProperty(false);
+    private final BooleanProperty isAnalyticsTab = new SimpleBooleanProperty(false);
     private final ObjectProperty<Analytics> targetAnalytics = new SimpleObjectProperty<>();
 
     /**
@@ -213,7 +214,23 @@ public class ModelManager implements Model {
 
     @Override
     public void setIsLoansTab(Boolean isLoansTab) {
+        if (isLoansTab) {
+            this.isAnalyticsTab.setValue(false);
+        }
         this.isLoansTab.setValue(isLoansTab);
+    }
+
+    @Override
+    public BooleanProperty getIsAnalyticsTab() {
+        return this.isAnalyticsTab;
+    }
+
+    @Override
+    public void setIsAnalyticsTab(Boolean isAnalyticsTab) {
+        if (isAnalyticsTab) {
+            this.isLoansTab.setValue(false);
+        }
+        this.isAnalyticsTab.setValue(isAnalyticsTab);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -9,13 +9,16 @@ import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.LinkLoanCommand;
+import seedu.address.model.person.Analytics;
 import seedu.address.model.person.Loan;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniqueLoanList;
@@ -32,6 +35,7 @@ public class ModelManager implements Model {
     private final FilteredList<Loan> filteredLoans;
     private final SortedList<Loan> sortedLoans;
     private final BooleanProperty isLoansTab = new SimpleBooleanProperty(false);
+    private final ObjectProperty<Analytics> targetAnalytics = new SimpleObjectProperty<>();
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -46,6 +50,7 @@ public class ModelManager implements Model {
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
         filteredLoans = new FilteredList<>(this.addressBook.getLoanList());
         sortedLoans = new SortedList<>(filteredLoans, Loan::compareTo);
+        targetAnalytics.setValue();
     }
 
     public ModelManager() {
@@ -172,11 +177,6 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public UniqueLoanList getUniqueLoanList() {
-        return addressBook.getUniqueLoanList();
-    }
-
-    @Override
     public void updateFilteredLoanList(Predicate<Loan> predicate) {
         requireNonNull(predicate);
         filteredLoans.setPredicate(predicate);
@@ -214,6 +214,16 @@ public class ModelManager implements Model {
     @Override
     public void setIsLoansTab(Boolean isLoansTab) {
         this.isLoansTab.setValue(isLoansTab);
+    }
+
+    @Override
+    public ObjectProperty<Analytics> getAnalytics() {
+        return targetAnalytics;
+    }
+
+    @Override
+    public void setAnalytics(Analytics analytics) {
+        targetAnalytics.setValue(analytics);
     }
 
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -50,7 +50,7 @@ public class ModelManager implements Model {
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
         filteredLoans = new FilteredList<>(this.addressBook.getLoanList());
         sortedLoans = new SortedList<>(filteredLoans, Loan::compareTo);
-        targetAnalytics.setValue();
+        targetAnalytics.setValue(null);
     }
 
     public ModelManager() {

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -226,6 +226,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void setToPersonTab() {
+        this.isLoansTab.setValue(false);
+        this.isAnalyticsTab.setValue(false);
+    }
+
+    @Override
     public void setIsAnalyticsTab(Boolean isAnalyticsTab) {
         if (isAnalyticsTab) {
             this.isLoansTab.setValue(false);

--- a/src/main/java/seedu/address/model/person/Analytics.java
+++ b/src/main/java/seedu/address/model/person/Analytics.java
@@ -1,5 +1,7 @@
 package seedu.address.model.person;
 
+import javafx.collections.ObservableList;
+
 import java.util.Date;
 
 /**
@@ -51,6 +53,7 @@ public class Analytics {
 
     /**
      * Updates the fields that count the number of various loans.
+     *
      * @param loan The loan to update the fields with.
      */
     private void updateNumFields(Loan loan) {
@@ -76,6 +79,7 @@ public class Analytics {
 
     /**
      * Updates the fields that calculate the total value of various loans.
+     *
      * @param loan The loan to update the fields with.
      */
     private void updateValueFields(Loan loan) {
@@ -106,6 +110,7 @@ public class Analytics {
 
     /**
      * Updates the fields that calculate the earliest and latest dates of various loans.
+     *
      * @param loan The loan to update the fields with.
      */
     private void updateDateFields(Loan loan) {
@@ -127,10 +132,25 @@ public class Analytics {
 
     /**
      * Returns an Analytics object that represents the analytics of a LoanRecords object.
+     *
      * @param uniqueLoanList The LoanRecords object to get the analytics from.
      * @return The Analytics object that represents the analytics of the LoanRecords object.
      */
-    public static Analytics getAnalytics(UniqueLoanList uniqueLoanList) {
+//    public static Analytics getAnalytics(UniqueLoanList uniqueLoanList) {
+//        Analytics analytics = new Analytics();
+//        for (int i = 0; i < uniqueLoanList.size(); i++) {
+//            Loan loan = uniqueLoanList.getLoan(i);
+//            analytics.updateNumFields(loan);
+//            analytics.updateValueFields(loan);
+//            analytics.updateDateFields(loan);
+//        }
+//        analytics.updatePropFields();
+//        analytics.updateAverageFields();
+//        return analytics;
+//    }
+    public static Analytics getAnalytics(ObservableList<Loan> loanList) {
+        UniqueLoanList uniqueLoanList = new UniqueLoanList();
+        uniqueLoanList.setLoans(loanList);
         Analytics analytics = new Analytics();
         for (int i = 0; i < uniqueLoanList.size(); i++) {
             Loan loan = uniqueLoanList.getLoan(i);

--- a/src/main/java/seedu/address/model/person/Analytics.java
+++ b/src/main/java/seedu/address/model/person/Analytics.java
@@ -1,8 +1,8 @@
 package seedu.address.model.person;
 
-import javafx.collections.ObservableList;
-
 import java.util.Date;
+
+import javafx.collections.ObservableList;
 
 /**
  * Represents the analytics of a LoanRecords object.
@@ -133,21 +133,9 @@ public class Analytics {
     /**
      * Returns an Analytics object that represents the analytics of a LoanRecords object.
      *
-     * @param uniqueLoanList The LoanRecords object to get the analytics from.
+     * @param loanList The list of loans to calculate the analytics from.
      * @return The Analytics object that represents the analytics of the LoanRecords object.
      */
-//    public static Analytics getAnalytics(UniqueLoanList uniqueLoanList) {
-//        Analytics analytics = new Analytics();
-//        for (int i = 0; i < uniqueLoanList.size(); i++) {
-//            Loan loan = uniqueLoanList.getLoan(i);
-//            analytics.updateNumFields(loan);
-//            analytics.updateValueFields(loan);
-//            analytics.updateDateFields(loan);
-//        }
-//        analytics.updatePropFields();
-//        analytics.updateAverageFields();
-//        return analytics;
-//    }
     public static Analytics getAnalytics(ObservableList<Loan> loanList) {
         UniqueLoanList uniqueLoanList = new UniqueLoanList();
         uniqueLoanList.setLoans(loanList);

--- a/src/main/java/seedu/address/ui/AnalyticsPanel.java
+++ b/src/main/java/seedu/address/ui/AnalyticsPanel.java
@@ -5,6 +5,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.chart.PieChart;
+import javafx.scene.control.Label;
 import javafx.scene.layout.Region;
 import seedu.address.model.person.Analytics;
 
@@ -19,18 +20,20 @@ public class AnalyticsPanel extends UiPart<Region> {
      */
     public AnalyticsPanel(ObjectProperty<Analytics> analytics) {
         super(FXML);
+        pieChart.setData(FXCollections.observableArrayList());
         analytics.addListener((observable, oldValue, newValue) -> {
             updateChart(newValue);
         });
     }
 
     private void updateChart(Analytics analytics) {
-        System.out.println("Updated Chart due to change in analytics");
-        pieChart.getData().clear();
+        System.out.println("Updating chart");
         ObservableList<PieChart.Data> pieChartData = FXCollections.observableArrayList(
-                new PieChart.Data("Overdue", analytics.getNumOverdueLoans()),
-                new PieChart.Data("Not Overdue", analytics.getNumLoans() - analytics.getNumOverdueLoans())
+                new PieChart.Data("Active Loans", analytics.getNumActiveLoans()),
+                new PieChart.Data("Overdue Loans", analytics.getNumOverdueLoans())
         );
         pieChart.setData(pieChartData);
     }
+    
+
 }

--- a/src/main/java/seedu/address/ui/AnalyticsPanel.java
+++ b/src/main/java/seedu/address/ui/AnalyticsPanel.java
@@ -29,7 +29,6 @@ public class AnalyticsPanel extends UiPart<Region> {
     }
 
     private void updateChart(Analytics analytics) {
-        System.out.println("Updating chart");
         ObservableList<PieChart.Data> pieChartData = FXCollections.observableArrayList(
                 new PieChart.Data("Active Loans", analytics.getNumActiveLoans()),
                 new PieChart.Data("Overdue Loans", analytics.getNumOverdueLoans())

--- a/src/main/java/seedu/address/ui/AnalyticsPanel.java
+++ b/src/main/java/seedu/address/ui/AnalyticsPanel.java
@@ -34,6 +34,4 @@ public class AnalyticsPanel extends UiPart<Region> {
         );
         pieChart.setData(pieChartData);
     }
-    
-
 }

--- a/src/main/java/seedu/address/ui/AnalyticsPanel.java
+++ b/src/main/java/seedu/address/ui/AnalyticsPanel.java
@@ -1,0 +1,35 @@
+package seedu.address.ui;
+
+import javafx.beans.property.ObjectProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.chart.PieChart;
+import javafx.scene.layout.Region;
+import seedu.address.model.person.Analytics;
+
+public class AnalyticsPanel extends UiPart<Region> {
+    private static final String FXML = "AnalyticsPanel.fxml";
+
+    @FXML
+    private PieChart pieChart;
+
+    /**
+     * Creates a {@code AnalyticsPanel} with the given {@code ObjectProperty}.
+     */
+    public AnalyticsPanel(ObjectProperty<Analytics> analytics) {
+        super(FXML);
+        analytics.addListener((observable, oldValue, newValue) -> {
+            updateChart(newValue);
+        });
+    }
+
+    private void updateChart(Analytics analytics) {
+        pieChart.getData().clear();
+        ObservableList<PieChart.Data> pieChartData = FXCollections.observableArrayList(
+                new PieChart.Data("Overdue", analytics.getNumOverdueLoans()),
+                new PieChart.Data("Not Overdue", analytics.getNumLoans() - analytics.getNumOverdueLoans())
+        );
+        pieChart.setData(pieChartData);
+    }
+}

--- a/src/main/java/seedu/address/ui/AnalyticsPanel.java
+++ b/src/main/java/seedu/address/ui/AnalyticsPanel.java
@@ -25,6 +25,7 @@ public class AnalyticsPanel extends UiPart<Region> {
     }
 
     private void updateChart(Analytics analytics) {
+        System.out.println("Updated Chart due to change in analytics");
         pieChart.getData().clear();
         ObservableList<PieChart.Data> pieChartData = FXCollections.observableArrayList(
                 new PieChart.Data("Overdue", analytics.getNumOverdueLoans()),

--- a/src/main/java/seedu/address/ui/AnalyticsPanel.java
+++ b/src/main/java/seedu/address/ui/AnalyticsPanel.java
@@ -5,10 +5,12 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.chart.PieChart;
-import javafx.scene.control.Label;
 import javafx.scene.layout.Region;
 import seedu.address.model.person.Analytics;
 
+/**
+ * Panel containing the analytics of the loan records.
+ */
 public class AnalyticsPanel extends UiPart<Region> {
     private static final String FXML = "AnalyticsPanel.fxml";
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -9,7 +9,9 @@ import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextInputControl;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.Priority;
 import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
@@ -62,6 +64,12 @@ public class MainWindow extends UiPart<Stage> {
 
     @FXML
     private StackPane analyticsPanelPlaceholder;
+    @FXML
+    private VBox loanList;
+    @FXML
+    private VBox analytics;
+    @FXML
+    private VBox personList;
 
     private BooleanProperty isLoansTab;
 
@@ -155,11 +163,9 @@ public class MainWindow extends UiPart<Stage> {
         logic.setIsAnalyticsTab(false);
         logic.setIsLoansTab(false);
         this.isLoansTab.addListener((observable, oldValue, newValue) -> {
-            System.out.println("Toggling tabs due to loan change");
             toggleTabs();
         });
         this.isAnalyticsTab.addListener((observable, oldValue, newValue) -> {
-            System.out.println("Toggleing tabs due to analytics change");
             toggleTabs();
         });
     }
@@ -170,24 +176,27 @@ public class MainWindow extends UiPart<Stage> {
 
         if (!this.isLoansTab.getValue() && !this.isAnalyticsTab.getValue()) {
             // Default to person list panel
-            System.out.println("Defaulting to person list panel");
             clearAllPlaceholders();
+            VBox.setVgrow(personList, Priority.ALWAYS);
             personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
         } else if (this.isLoansTab.getValue()) {
-            System.out.println("Switching to loan list panel");
             clearAllPlaceholders();
+            VBox.setVgrow(loanList, Priority.ALWAYS);
             loanListPanelPlaceholder.getChildren().add(loanListPanel.getRoot());
         } else {
-            System.out.println("Switching to analytics panel");
             clearAllPlaceholders();
+            VBox.setVgrow(analytics, Priority.ALWAYS);
             analyticsPanelPlaceholder.getChildren().add(analyticsPanel.getRoot());
         }
     }
 
     private void clearAllPlaceholders() {
         personListPanelPlaceholder.getChildren().clear();
+        VBox.setVgrow(personList, Priority.NEVER);
         loanListPanelPlaceholder.getChildren().clear();
+        VBox.setVgrow(loanList, Priority.NEVER);
         analyticsPanelPlaceholder.getChildren().clear();
+        VBox.setVgrow(analytics, Priority.NEVER);
     }
 
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -121,7 +121,8 @@ public class MainWindow extends UiPart<Stage> {
      */
     void fillInnerParts() {
         this.isLoansTab = logic.getIsLoansTab();
-
+        // Initial value of isLoansTab is false by default
+        assert (!this.isLoansTab.getValue());
 
         personListPanel = new PersonListPanel(logic.getFilteredPersonList());
         // By default, the person list panel is shown
@@ -138,7 +139,6 @@ public class MainWindow extends UiPart<Stage> {
                 personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
             }
         });
-
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -57,6 +57,9 @@ public class MainWindow extends UiPart<Stage> {
     @FXML
     private StackPane loanListPanelPlaceholder;
 
+    @FXML
+    private AnalyticsPanel analyticsPanel;
+
     private BooleanProperty isLoansTab;
 
     /**
@@ -139,7 +142,7 @@ public class MainWindow extends UiPart<Stage> {
                 personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
             }
         });
-
+        this.analyticsPanel = new AnalyticsPanel(logic.getAnalytics());
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -60,6 +60,9 @@ public class MainWindow extends UiPart<Stage> {
     @FXML
     private AnalyticsPanel analyticsPanel;
 
+    @FXML
+    private StackPane analyticsPanelPlaceholder;
+
     private BooleanProperty isLoansTab;
 
     /**
@@ -142,7 +145,8 @@ public class MainWindow extends UiPart<Stage> {
                 personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
             }
         });
-        this.analyticsPanel = new AnalyticsPanel(logic.getAnalytics());
+        analyticsPanel = new AnalyticsPanel(logic.getAnalytics());
+        analyticsPanelPlaceholder.getChildren().add(analyticsPanel.getRoot());
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
 

--- a/src/main/resources/view/AnalyticsPanel.fxml
+++ b/src/main/resources/view/AnalyticsPanel.fxml
@@ -3,7 +3,9 @@
 <?import javafx.scene.chart.PieChart?>
 <?import javafx.scene.layout.AnchorPane?>
 
-<AnchorPane xmlns:fx="http://javafx.com/fxml" fx:id="root" prefHeight="400.0" prefWidth="600.0"
-            xmlns="http://javafx.com/javafx/17">
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.control.Label?>
+<VBox xmlns:fx="http://javafx.com/fxml" prefHeight="400.0" prefWidth="600.0"
+      xmlns="http://javafx.com/javafx/17">
     <PieChart fx:id="pieChart" layoutX="48.0" layoutY="48.0" prefHeight="304.0" prefWidth="504.0"/>
-</AnchorPane>
+</VBox>

--- a/src/main/resources/view/AnalyticsPanel.fxml
+++ b/src/main/resources/view/AnalyticsPanel.fxml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.chart.PieChart?>
+<?import javafx.scene.layout.AnchorPane?>
+
+<AnchorPane xmlns:fx="http://javafx.com/fxml" fx:id="root" prefHeight="400.0" prefWidth="600.0"
+            xmlns="http://javafx.com/javafx/17" fx:controller="seedu.address.ui.AnalyticsPanel">
+    <PieChart fx:id="pieChart" layoutX="48.0" layoutY="48.0" prefHeight="304.0" prefWidth="504.0"/>
+</AnchorPane>

--- a/src/main/resources/view/AnalyticsPanel.fxml
+++ b/src/main/resources/view/AnalyticsPanel.fxml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.scene.chart.PieChart?>
-<?import javafx.scene.layout.AnchorPane?>
-
 <?import javafx.scene.layout.VBox?>
-<?import javafx.scene.control.Label?>
+
 <VBox xmlns:fx="http://javafx.com/fxml" prefHeight="400.0" prefWidth="600.0"
       xmlns="http://javafx.com/javafx/17">
     <PieChart fx:id="pieChart" layoutX="48.0" layoutY="48.0" prefHeight="304.0" prefWidth="504.0"/>

--- a/src/main/resources/view/AnalyticsPanel.fxml
+++ b/src/main/resources/view/AnalyticsPanel.fxml
@@ -4,6 +4,6 @@
 <?import javafx.scene.layout.AnchorPane?>
 
 <AnchorPane xmlns:fx="http://javafx.com/fxml" fx:id="root" prefHeight="400.0" prefWidth="600.0"
-            xmlns="http://javafx.com/javafx/17" fx:controller="seedu.address.ui.AnalyticsPanel">
+            xmlns="http://javafx.com/javafx/17">
     <PieChart fx:id="pieChart" layoutX="48.0" layoutY="48.0" prefHeight="304.0" prefWidth="504.0"/>
 </AnchorPane>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -48,16 +48,16 @@
 
                 <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="340"
                       VBox.vgrow="ALWAYS">
-                    <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+                    <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="NEVER"/>
                 </VBox>
 
                 <VBox fx:id="analytics" styleClass="pane-with-border" minWidth="340" prefWidth="340"
                       VBox.vgrow="ALWAYS">
-                    <StackPane fx:id="analyticsPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+                    <StackPane fx:id="analyticsPanelPlaceholder" VBox.vgrow="NEVER"/>
                 </VBox>
 
                 <VBox fx:id="loanList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
-                    <StackPane fx:id="loanListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+                    <StackPane fx:id="loanListPanelPlaceholder" VBox.vgrow="NEVER"/>
                 </VBox>
                 <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER"/>
             </VBox>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -48,24 +48,15 @@
 
                 <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="340"
                       VBox.vgrow="ALWAYS">
-                    <padding>
-                        <Insets top="10" right="10" bottom="10" left="10"/>
-                    </padding>
                     <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
                 </VBox>
 
                 <VBox fx:id="analytics" styleClass="pane-with-border" minWidth="340" prefWidth="340"
                       VBox.vgrow="ALWAYS">
-                    <padding>
-                        <Insets top="10" right="10" bottom="10" left="10"/>
-                    </padding>
                     <StackPane fx:id="analyticsPanelPlaceholder" VBox.vgrow="ALWAYS"/>
                 </VBox>
 
                 <VBox fx:id="loanList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
-                    <padding>
-                        <Insets top="10" right="10" bottom="10" left="10"/>
-                    </padding>
                     <StackPane fx:id="loanListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
                 </VBox>
                 <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER"/>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -46,6 +46,15 @@
                     </padding>
                 </StackPane>
 
+
+                <VBox fx:id="analytics" styleClass="pane-with-border" minWidth="340" prefWidth="340"
+                      VBox.vgrow="ALWAYS">
+                    <padding>
+                        <Insets top="10" right="10" bottom="10" left="10"/>
+                    </padding>
+                    <StackPane fx:id="analyticsPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+                </VBox>
+
                 <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="340"
                       VBox.vgrow="ALWAYS">
                     <padding>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -46,6 +46,13 @@
                     </padding>
                 </StackPane>
 
+                <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="340"
+                      VBox.vgrow="ALWAYS">
+                    <padding>
+                        <Insets top="10" right="10" bottom="10" left="10"/>
+                    </padding>
+                    <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+                </VBox>
 
                 <VBox fx:id="analytics" styleClass="pane-with-border" minWidth="340" prefWidth="340"
                       VBox.vgrow="ALWAYS">
@@ -53,14 +60,6 @@
                         <Insets top="10" right="10" bottom="10" left="10"/>
                     </padding>
                     <StackPane fx:id="analyticsPanelPlaceholder" VBox.vgrow="ALWAYS"/>
-                </VBox>
-
-                <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="340"
-                      VBox.vgrow="ALWAYS">
-                    <padding>
-                        <Insets top="10" right="10" bottom="10" left="10"/>
-                    </padding>
-                    <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
                 </VBox>
 
                 <VBox fx:id="loanList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -16,6 +16,7 @@ import java.util.function.Predicate;
 import org.junit.jupiter.api.Test;
 
 import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ObjectProperty;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.Messages;
@@ -24,9 +25,9 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.person.Analytics;
 import seedu.address.model.person.Loan;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.UniqueLoanList;
 import seedu.address.testutil.PersonBuilder;
 
 public class AddCommandTest {
@@ -198,6 +199,16 @@ public class AddCommandTest {
         }
 
         @Override
+        public void setAnalytics(Analytics analytics) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObjectProperty<Analytics> getAnalytics() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void deleteLoan(Loan loan) {
             throw new AssertionError("This method should not be called.");
         }
@@ -213,9 +224,20 @@ public class AddCommandTest {
         }
 
         @Override
-        public UniqueLoanList getUniqueLoanList() {
+        public void setIsAnalyticsTab(Boolean isAnalyticsTab) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public BooleanProperty getIsAnalyticsTab() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setToPersonTab() {
+            throw new AssertionError("This method should not be called.");
+        }
+
     }
 
     /**


### PR DESCRIPTION
This PR resolves part 1 (tab switching) of issue #84.

## Changelog

#### Classes added

- `AnalyticsPanel.java`

#### Behaviour changes

- `Model` now has 2 variables - `isLoansTab` and `isAnalyticsTab`. If both are false, UI defaults to contact (personList) view
- Add listeners in GUI to implement tab switching

#### Notes

- The current analytics GUI is a dummy version. It shows a single piechart of overdueLoans against totalLoans (EDIT: the piechart representation may be wrong, current implementation is for demonstration purposes and to test tab switching only)
- Removed padding in `MainWindow`'s VBox to remove the gap between placeholders. (The issue of the black line getting slightly thicker is still persistent but is less noticeable than the gap)