### PR TITLE
Implement analytics GUI (Part 2 - Piechart Display)

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -10,6 +10,7 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.analytics.DashboardData;
 import seedu.address.model.person.Analytics;
 import seedu.address.model.person.Loan;
 import seedu.address.model.person.Person;
@@ -67,5 +68,5 @@ public interface Logic {
 
     void setToPersonTab();
 
-    ObjectProperty<Analytics> getAnalytics();
+    ObjectProperty<DashboardData> getAnalytics();
 }

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -11,7 +11,6 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.analytics.DashboardData;
-import seedu.address.model.person.Analytics;
 import seedu.address.model.person.Loan;
 import seedu.address.model.person.Person;
 

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -17,6 +17,7 @@ import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.analytics.DashboardData;
 import seedu.address.model.person.Analytics;
 import seedu.address.model.person.Loan;
 import seedu.address.model.person.Person;
@@ -106,7 +107,7 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public ObjectProperty<Analytics> getAnalytics() {
+    public ObjectProperty<DashboardData> getAnalytics() {
         return model.getDashboardData();
     }
 

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -18,7 +18,6 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.analytics.DashboardData;
-import seedu.address.model.person.Analytics;
 import seedu.address.model.person.Loan;
 import seedu.address.model.person.Person;
 import seedu.address.storage.Storage;

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -107,7 +107,7 @@ public class LogicManager implements Logic {
 
     @Override
     public ObjectProperty<Analytics> getAnalytics() {
-        return model.getAnalytics();
+        return model.getDashboardData();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AnalyticsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AnalyticsCommand.java
@@ -41,7 +41,7 @@ public class AnalyticsCommand extends Command {
         model.generateDashboardData(targetAnalytics);
         model.setIsAnalyticsTab(true);
 
-        return new CommandResult(MESSAGE_SUCCESS + model.getDashboardData().getValue(),
+        return new CommandResult(MESSAGE_SUCCESS + " for " + targetPerson.getName(),
                 false, false, false);
     }
 

--- a/src/main/java/seedu/address/logic/commands/AnalyticsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AnalyticsCommand.java
@@ -37,10 +37,11 @@ public class AnalyticsCommand extends Command {
         Person targetPerson = lastShownList.get(targetIndex.getZeroBased());
         model.updateFilteredLoanList(loan -> loan.isAssignedTo(targetPerson) && loan.isActive());
         Analytics targetAnalytics = Analytics.getAnalytics(model.getSortedLoanList());
-        // TODO: Implement analytics GUI display logic
-        model.setAnalytics(targetAnalytics);
+
+        model.generateDashboardData(targetAnalytics);
         model.setIsAnalyticsTab(true);
-        return new CommandResult(MESSAGE_SUCCESS + model.getAnalytics().getValue(),
+
+        return new CommandResult(MESSAGE_SUCCESS + model.getDashboardData().getValue(),
                 false, false, false);
     }
 

--- a/src/main/java/seedu/address/logic/commands/AnalyticsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AnalyticsCommand.java
@@ -35,13 +35,13 @@ public class AnalyticsCommand extends Command {
         }
 
         Person targetPerson = lastShownList.get(targetIndex.getZeroBased());
-        model.updateFilteredLoanList(loan -> loan.isAssignedTo(targetPerson) && loan.isActive());
+        model.updateFilteredLoanList(loan -> loan.isAssignedTo(targetPerson));
         Analytics targetAnalytics = Analytics.getAnalytics(model.getSortedLoanList());
 
         model.generateDashboardData(targetAnalytics);
         model.setIsAnalyticsTab(true);
 
-        return new CommandResult(MESSAGE_SUCCESS + " for " + targetPerson.getName(),
+        return new CommandResult(MESSAGE_SUCCESS + " for " + targetPerson.getName() + " ",
                 false, false, false);
     }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -155,9 +155,5 @@ public interface Model {
 
     void unmarkLoan(Loan loanToUnmark);
 
-    void setAnalytics(Analytics analytics);
-
-    ObjectProperty<Analytics> getAnalytics();
-
     ObjectProperty<DashboardData> getDashboardData();
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.Date;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -9,6 +10,7 @@ import javafx.beans.property.ObjectProperty;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.LinkLoanCommand;
+import seedu.address.model.analytics.DashboardData;
 import seedu.address.model.person.Analytics;
 import seedu.address.model.person.Loan;
 import seedu.address.model.person.Person;
@@ -150,9 +152,7 @@ public interface Model {
 
     void markLoan(Loan loanToMark);
 
-    void setAnalytics(Analytics analytics);
+    void generateDashboardData(Analytics analytics);
 
-    ObjectProperty<Analytics> getAnalytics();
-
-
+    ObjectProperty<DashboardData> getDashboardData();
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,7 +1,6 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
-import java.util.Date;
 import java.util.List;
 import java.util.function.Predicate;
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -250,6 +250,5 @@ public class ModelManager implements Model {
         float impactBenchmark = this.addressBook.getUniqueLoanList().getMaxLoanValue();
         Date urgencyBenchmark = this.addressBook.getUniqueLoanList().getEarliestReturnDate();
         dashboardData.setValue(new DashboardData(analytics, impactBenchmark, urgencyBenchmark));
-        System.out.println(dashboardData.getValue().toString());
     }
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -250,5 +250,6 @@ public class ModelManager implements Model {
         float impactBenchmark = this.addressBook.getUniqueLoanList().getMaxLoanValue();
         Date urgencyBenchmark = this.addressBook.getUniqueLoanList().getEarliestReturnDate();
         dashboardData.setValue(new DashboardData(analytics, impactBenchmark, urgencyBenchmark));
+        System.out.println(dashboardData.getValue().toString());
     }
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.Date;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
@@ -18,6 +19,7 @@ import javafx.collections.transformation.SortedList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.LinkLoanCommand;
+import seedu.address.model.analytics.DashboardData;
 import seedu.address.model.person.Analytics;
 import seedu.address.model.person.Loan;
 import seedu.address.model.person.Person;
@@ -35,7 +37,7 @@ public class ModelManager implements Model {
     private final SortedList<Loan> sortedLoans;
     private final BooleanProperty isLoansTab = new SimpleBooleanProperty(false);
     private final BooleanProperty isAnalyticsTab = new SimpleBooleanProperty(false);
-    private final ObjectProperty<Analytics> targetAnalytics = new SimpleObjectProperty<>();
+    private final ObjectProperty<DashboardData> dashboardData = new SimpleObjectProperty<>();
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -50,7 +52,7 @@ public class ModelManager implements Model {
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
         filteredLoans = new FilteredList<>(this.addressBook.getLoanList());
         sortedLoans = new SortedList<>(filteredLoans, Loan::compareTo);
-        targetAnalytics.setValue(null);
+        dashboardData.setValue(null);
     }
 
     public ModelManager() {
@@ -239,13 +241,14 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public ObjectProperty<Analytics> getAnalytics() {
-        return targetAnalytics;
+    public ObjectProperty<DashboardData> getDashboardData() {
+        return dashboardData;
     }
 
     @Override
-    public void setAnalytics(Analytics analytics) {
-        targetAnalytics.setValue(analytics);
+    public void generateDashboardData(Analytics analytics) {
+        float impactBenchmark = this.addressBook.getUniqueLoanList().getMaxLoanValue();
+        Date urgencyBenchmark = this.addressBook.getUniqueLoanList().getEarliestReturnDate();
+        dashboardData.setValue(new DashboardData(analytics, impactBenchmark, urgencyBenchmark));
     }
-
 }

--- a/src/main/java/seedu/address/model/analytics/DashboardData.java
+++ b/src/main/java/seedu/address/model/analytics/DashboardData.java
@@ -33,6 +33,16 @@ public class DashboardData {
     }
 
     /**
+     * Calculates the impact index of the dashboard data
+     * Impact index is calculated as the ratio of the average loan value to the maximum loan value
+     *
+     * @return impact index between 0 and 1
+     */
+    public float getImpactIndex() {
+        return analytics.getAverageLoanValue() / maxLoanValue;
+    }
+
+    /**
      * Calculates the urgency index of the dashboard data
      * Urgency index is calculated as the ratio of the number of days between the earliest return date and the current date
      * to the number of days between the earliest return date and the benchmark date

--- a/src/main/java/seedu/address/model/analytics/DashboardData.java
+++ b/src/main/java/seedu/address/model/analytics/DashboardData.java
@@ -56,13 +56,23 @@ public class DashboardData {
      *
      * @return urgency index between 0 and 1
      */
-    public float getUrgencyIndex() {
+    public Float getUrgencyIndex() {
         // Should take extra measures to ensure no overdue loans are used for calculations
+        if (analytics.getEarliestReturnDate() == null || earliestReturnDate == null) {
+            return null;
+        }
         LocalDate target = analytics.getEarliestReturnDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
         LocalDate benchmark = this.earliestReturnDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
         LocalDate now = LocalDate.now();
         long dayDiffBenchmark = benchmark.toEpochDay() - now.toEpochDay();
         long dayDiffTarget = target.toEpochDay() - now.toEpochDay();
+        System.out.println("HERE" + dayDiffBenchmark / dayDiffTarget);
         return (float) dayDiffBenchmark / dayDiffTarget;
+    }
+
+    @Override
+    public String toString() {
+        return "Analytics: " + analytics + ", Max Loan Value: " + maxLoanValue + ", Earliest Return Date: "
+                + earliestReturnDate;
     }
 }

--- a/src/main/java/seedu/address/model/analytics/DashboardData.java
+++ b/src/main/java/seedu/address/model/analytics/DashboardData.java
@@ -1,11 +1,11 @@
 package seedu.address.model.analytics;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
 
 import seedu.address.model.person.Analytics;
 
-import java.time.ZoneId;
-import java.util.Date;
 
 /**
  * Represents the analytics data of the dashboard with 3 values
@@ -18,6 +18,13 @@ public class DashboardData {
     private float maxLoanValue;
     private Date earliestReturnDate;
 
+    /**
+     * Creates a DashboardData object with the given analytics, max loan value and earliest return date
+     *
+     * @param analytics analytics object to be displayed
+     * @param maxLoanValue maximum loan value of all loans
+     * @param earliestReturnDate earliest return date of all loans (not returned and not overdue)
+     */
     public DashboardData(Analytics analytics, float maxLoanValue, Date earliestReturnDate) {
         this.analytics = analytics;
         this.maxLoanValue = maxLoanValue;
@@ -44,7 +51,7 @@ public class DashboardData {
 
     /**
      * Calculates the urgency index of the dashboard data
-     * Urgency index is calculated as the ratio of the number of days between the earliest return date and the current date
+     * Urgency index is calculated as the ratio of the number of days between the earliest return date and the current
      * to the number of days between the earliest return date and the benchmark date
      *
      * @return urgency index between 0 and 1

--- a/src/main/java/seedu/address/model/analytics/DashboardData.java
+++ b/src/main/java/seedu/address/model/analytics/DashboardData.java
@@ -66,7 +66,6 @@ public class DashboardData {
         LocalDate now = LocalDate.now();
         long dayDiffBenchmark = benchmark.toEpochDay() - now.toEpochDay();
         long dayDiffTarget = target.toEpochDay() - now.toEpochDay();
-        System.out.println("HERE" + dayDiffBenchmark / dayDiffTarget);
         return (float) dayDiffBenchmark / dayDiffTarget;
     }
 

--- a/src/main/java/seedu/address/model/analytics/DashboardData.java
+++ b/src/main/java/seedu/address/model/analytics/DashboardData.java
@@ -1,8 +1,10 @@
 package seedu.address.model.analytics;
 
-import seedu.address.logic.commands.AnalyticsCommand;
+import java.time.LocalDate;
+
 import seedu.address.model.person.Analytics;
 
+import java.time.ZoneId;
 import java.util.Date;
 
 /**
@@ -30,7 +32,20 @@ public class DashboardData {
         return maxLoanValue;
     }
 
-    public Date getEarliestReturnDate() {
-        return earliestReturnDate;
+    /**
+     * Calculates the urgency index of the dashboard data
+     * Urgency index is calculated as the ratio of the number of days between the earliest return date and the current date
+     * to the number of days between the earliest return date and the benchmark date
+     *
+     * @return urgency index between 0 and 1
+     */
+    public float getUrgencyIndex() {
+        // Should take extra measures to ensure no overdue loans are used for calculations
+        LocalDate target = analytics.getEarliestReturnDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+        LocalDate benchmark = this.earliestReturnDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+        LocalDate now = LocalDate.now();
+        long dayDiffBenchmark = benchmark.toEpochDay() - now.toEpochDay();
+        long dayDiffTarget = target.toEpochDay() - now.toEpochDay();
+        return (float) dayDiffBenchmark / dayDiffTarget;
     }
 }

--- a/src/main/java/seedu/address/model/analytics/DashboardData.java
+++ b/src/main/java/seedu/address/model/analytics/DashboardData.java
@@ -1,0 +1,36 @@
+package seedu.address.model.analytics;
+
+import seedu.address.logic.commands.AnalyticsCommand;
+import seedu.address.model.person.Analytics;
+
+import java.util.Date;
+
+/**
+ * Represents the analytics data of the dashboard with 3 values
+ * - Analytics object to be displayed
+ * - Max loan value
+ * - Earliest return date
+ */
+public class DashboardData {
+    private Analytics analytics;
+    private float maxLoanValue;
+    private Date earliestReturnDate;
+
+    public DashboardData(Analytics analytics, float maxLoanValue, Date earliestReturnDate) {
+        this.analytics = analytics;
+        this.maxLoanValue = maxLoanValue;
+        this.earliestReturnDate = earliestReturnDate;
+    }
+
+    public Analytics getAnalytics() {
+        return analytics;
+    }
+
+    public float getMaxLoanValue() {
+        return maxLoanValue;
+    }
+
+    public Date getEarliestReturnDate() {
+        return earliestReturnDate;
+    }
+}

--- a/src/main/java/seedu/address/model/person/UniqueLoanList.java
+++ b/src/main/java/seedu/address/model/person/UniqueLoanList.java
@@ -312,6 +312,11 @@ public class UniqueLoanList implements Iterable<Loan> {
         }
     }
 
+    /**
+     * Returns the maximum loan value of all loans.
+     *
+     * @return The maximum loan value of all loans.
+     */
     public int getMaxLoanValue() {
         int maxLoanValue = 0;
         for (Loan loan : internalList) {
@@ -322,10 +327,17 @@ public class UniqueLoanList implements Iterable<Loan> {
         return maxLoanValue;
     }
 
+    /**
+     * Returns the earliest return date of all loans.
+     * The loan must not be overdue and must not have been returned.
+     *
+     * @return The earliest return date of all loans. Returns null if there are no loans that meet the criteria.
+     */
     public Date getEarliestReturnDate() {
         Date earliestReturnDate = null;
         for (Loan loan : internalList) {
-            if (earliestReturnDate == null || loan.getReturnDate().before(earliestReturnDate)) {
+            if ((earliestReturnDate == null || loan.getReturnDate().before(earliestReturnDate))
+                    && !loan.getReturnDate().before(new Date()) && !loan.isReturned()) {
                 earliestReturnDate = loan.getReturnDate();
             }
         }

--- a/src/main/java/seedu/address/model/person/UniqueLoanList.java
+++ b/src/main/java/seedu/address/model/person/UniqueLoanList.java
@@ -40,6 +40,7 @@ public class UniqueLoanList implements Iterable<Loan> {
 
     /**
      * Adds a loan to the list of loans.
+     *
      * @param loan A valid loan.
      */
     public void addLoan(Loan loan) {
@@ -50,6 +51,7 @@ public class UniqueLoanList implements Iterable<Loan> {
 
     /**
      * Adds a loan to the list of loans.
+     *
      * @param value A valid value.
      * @param startDate A valid start date.
      * @param returnDate A valid return date.
@@ -62,6 +64,7 @@ public class UniqueLoanList implements Iterable<Loan> {
 
     /**
      * Adds a loan to the list of loans.
+     *
      * @param loanDescription A valid LinkLoanDescriptor, which contains details about the loan to be added.
      */
     public Loan addLoan(LinkLoanDescriptor loanDescription, Person assignee) {
@@ -73,6 +76,7 @@ public class UniqueLoanList implements Iterable<Loan> {
 
     /**
      * Adds a loan to the list of loans.
+     *
      * @param value A valid value.
      * @param startDate A valid start date.
      * @param returnDate A valid return date.
@@ -91,6 +95,7 @@ public class UniqueLoanList implements Iterable<Loan> {
 
     /**
      * Removes a loan from the list of loans.
+     *
      * @param toRemove A valid loan.
      */
     public void removeLoan(Loan toRemove) {
@@ -147,6 +152,7 @@ public class UniqueLoanList implements Iterable<Loan> {
 
     /**
      * Marks a loan as returned.
+     *
      * @param idx A valid index.
      */
     public void markLoanAsReturned(int idx) {
@@ -155,6 +161,7 @@ public class UniqueLoanList implements Iterable<Loan> {
 
     /**
      * Marks a loan as returned.
+     *
      * @param id A valid id.
      */
     public void markLoanAsReturnedById(int id) {
@@ -166,6 +173,7 @@ public class UniqueLoanList implements Iterable<Loan> {
 
     /**
      * Marks a loan as not returned.
+     *
      * @param loanToMark A valid loan.
      */
     public void markLoan(Loan loanToMark) {
@@ -220,6 +228,7 @@ public class UniqueLoanList implements Iterable<Loan> {
     public int size() {
         return internalList.size();
     }
+
     @Override
     public String toString() {
         String output = "Loans:\n";
@@ -276,6 +285,7 @@ public class UniqueLoanList implements Iterable<Loan> {
 
     /**
      * Removes all loans attached to a person.
+     *
      * @param key A valid person.
      */
     public void removeLoansAttachedTo(Person key) {
@@ -285,6 +295,7 @@ public class UniqueLoanList implements Iterable<Loan> {
 
     /**
      * Modifies the assignee of all loans attached to a person.
+     *
      * @param target A valid person.
      * @param editedPerson A valid person.
      */
@@ -299,5 +310,25 @@ public class UniqueLoanList implements Iterable<Loan> {
         if (!internalList.isEmpty()) {
             internalList.set(0, internalList.get(0));
         }
+    }
+
+    public int getMaxLoanValue() {
+        int maxLoanValue = 0;
+        for (Loan loan : internalList) {
+            if (loan.getValue() > maxLoanValue) {
+                maxLoanValue = (int) loan.getValue();
+            }
+        }
+        return maxLoanValue;
+    }
+
+    public Date getEarliestReturnDate() {
+        Date earliestReturnDate = null;
+        for (Loan loan : internalList) {
+            if (earliestReturnDate == null || loan.getReturnDate().before(earliestReturnDate)) {
+                earliestReturnDate = loan.getReturnDate();
+            }
+        }
+        return earliestReturnDate;
     }
 }

--- a/src/main/java/seedu/address/ui/AnalyticsPanel.java
+++ b/src/main/java/seedu/address/ui/AnalyticsPanel.java
@@ -1,9 +1,5 @@
 package seedu.address.ui;
 
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.util.Date;
-
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -38,8 +34,6 @@ public class AnalyticsPanel extends UiPart<Region> {
 
     @FXML
     private Label urgencyIndex;
-
-    private static final float MAX_IMPACT = 1000000;
 
     /**
      * Creates a {@code AnalyticsPanel} with the given {@code ObjectProperty}.

--- a/src/main/java/seedu/address/ui/AnalyticsPanel.java
+++ b/src/main/java/seedu/address/ui/AnalyticsPanel.java
@@ -61,26 +61,38 @@ public class AnalyticsPanel extends UiPart<Region> {
 
     private void updateChart(DashboardData data) {
         Analytics analytics = data.getAnalytics();
-        ObservableList<PieChart.Data> reliabilityData = FXCollections.observableArrayList(
-                new PieChart.Data("Reliability Index", analytics.getPropOverdueLoans()),
-                new PieChart.Data("", 1 - analytics.getPropOverdueLoans())
-        );
-        reliabilityChart.setData(reliabilityData);
+        if (analytics.getNumActiveLoans() == 0) {
+            reliabilityIndex.setText("No active loans to analyze");
+            reliabilityChart.setDisable(true);
+        } else {
+            reliabilityChart.setDisable(false);
+            ObservableList<PieChart.Data> reliabilityData = FXCollections.observableArrayList(
+                    new PieChart.Data("Reliability Index", analytics.getPropOverdueLoans()),
+                    new PieChart.Data("", 1 - analytics.getPropOverdueLoans())
+            );
+            reliabilityChart.setData(reliabilityData);
+            reliabilityIndex.setText(String.format("%.2f", (1 - analytics.getPropOverdueLoans()) * 100) + "%");
+        }
+
 
         ObservableList<PieChart.Data> impactData = FXCollections.observableArrayList(
                 new PieChart.Data("Impact Index", data.getImpactIndex()),
                 new PieChart.Data("", 1 - data.getImpactIndex())
         );
         impactChart.setData(impactData);
-
-        ObservableList<PieChart.Data> urgencyData = FXCollections.observableArrayList(
-                new PieChart.Data("Urgency Index", data.getUrgencyIndex()),
-                new PieChart.Data("", 1 - data.getUrgencyIndex())
-        );
-        urgencyChart.setData(urgencyData);
-
-        reliabilityIndex.setText(String.format("%.2f", (1 - analytics.getPropOverdueLoans()) * 100) + "%");
         impactIndex.setText(String.format("%.2f", data.getImpactIndex() * 100) + "%");
-        urgencyIndex.setText(String.format("%.2f", data.getUrgencyIndex() * 100) + "%");
+
+        if (data.getUrgencyIndex() == null) {
+            urgencyIndex.setText("No loans to analyze");
+            urgencyChart.setDisable(true);
+        } else {
+            urgencyChart.setDisable(false);
+            ObservableList<PieChart.Data> urgencyData = FXCollections.observableArrayList(
+                    new PieChart.Data("Urgency Index", data.getUrgencyIndex()),
+                    new PieChart.Data("", 1 - data.getUrgencyIndex())
+            );
+            urgencyChart.setData(urgencyData);
+            urgencyIndex.setText(String.format("%.2f", data.getUrgencyIndex() * 100) + "%");
+        }
     }
 }

--- a/src/main/java/seedu/address/ui/AnalyticsPanel.java
+++ b/src/main/java/seedu/address/ui/AnalyticsPanel.java
@@ -75,12 +75,19 @@ public class AnalyticsPanel extends UiPart<Region> {
         }
 
 
-        ObservableList<PieChart.Data> impactData = FXCollections.observableArrayList(
-                new PieChart.Data("Impact Index", data.getImpactIndex()),
-                new PieChart.Data("", 1 - data.getImpactIndex())
-        );
-        impactChart.setData(impactData);
-        impactIndex.setText(String.format("%.2f", data.getImpactIndex() * 100) + "%");
+        if (data.getMaxLoanValue() == 0) {
+            impactIndex.setText("No loans to analyze");
+            impactChart.setDisable(true);
+        } else {
+            impactChart.setDisable(false);
+            ObservableList<PieChart.Data> impactData = FXCollections.observableArrayList(
+                    new PieChart.Data("Impact Index", data.getImpactIndex()),
+                    new PieChart.Data("", 1 - data.getImpactIndex())
+            );
+            impactChart.setData(impactData);
+            impactIndex.setText(String.format("%.2f", data.getImpactIndex() * 100) + "%");
+        }
+
 
         if (data.getUrgencyIndex() == null) {
             urgencyIndex.setText("No loans to analyze");

--- a/src/main/java/seedu/address/ui/AnalyticsPanel.java
+++ b/src/main/java/seedu/address/ui/AnalyticsPanel.java
@@ -87,10 +87,8 @@ public class AnalyticsPanel extends UiPart<Region> {
             impactChart.setData(impactData);
             impactIndex.setText(String.format("%.2f", data.getImpactIndex() * 100) + "%");
         }
-
-
         if (data.getUrgencyIndex() == null) {
-            urgencyIndex.setText("No loans to analyze");
+            urgencyIndex.setText("No due loans to analyze");
             urgencyChart.setVisible(false);
         } else {
             urgencyChart.setVisible(true);

--- a/src/main/java/seedu/address/ui/AnalyticsPanel.java
+++ b/src/main/java/seedu/address/ui/AnalyticsPanel.java
@@ -9,6 +9,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.chart.PieChart;
+import javafx.scene.control.Label;
 import javafx.scene.layout.Region;
 import seedu.address.model.analytics.DashboardData;
 import seedu.address.model.person.Analytics;
@@ -29,6 +30,15 @@ public class AnalyticsPanel extends UiPart<Region> {
     @FXML
     private PieChart urgencyChart;
 
+    @FXML
+    private Label reliabilityIndex;
+
+    @FXML
+    private Label impactIndex;
+
+    @FXML
+    private Label urgencyIndex;
+
     private static final float MAX_IMPACT = 1000000;
 
     /**
@@ -36,30 +46,47 @@ public class AnalyticsPanel extends UiPart<Region> {
      */
     public AnalyticsPanel(ObjectProperty<DashboardData> dashboardData) {
         super(FXML);
+        initializeCharts();
         reliabilityChart.setData(FXCollections.observableArrayList());
         dashboardData.addListener((observable, oldValue, newValue) -> {
             updateChart(newValue);
         });
     }
 
+    private void initializeCharts() {
+        reliabilityChart.setStartAngle(90);
+        impactChart.setStartAngle(90);
+        urgencyChart.setStartAngle(90);
+        reliabilityChart.setLabelsVisible(false);
+        impactChart.setLabelsVisible(false);
+        urgencyChart.setLabelsVisible(false);
+        reliabilityChart.setLegendVisible(false);
+        impactChart.setLegendVisible(false);
+        urgencyChart.setLegendVisible(false);
+    }
+
     private void updateChart(DashboardData data) {
         Analytics analytics = data.getAnalytics();
         ObservableList<PieChart.Data> reliabilityData = FXCollections.observableArrayList(
-                new PieChart.Data("Active Loans", analytics.getNumActiveLoans()),
-                new PieChart.Data("Overdue Loans", analytics.getNumActiveLoans() - analytics.getNumOverdueLoans())
+                new PieChart.Data("Reliability Index", analytics.getPropOverdueLoans()),
+                new PieChart.Data("", 1 - analytics.getPropOverdueLoans())
         );
         reliabilityChart.setData(reliabilityData);
 
         ObservableList<PieChart.Data> impactData = FXCollections.observableArrayList(
                 new PieChart.Data("Impact Index", data.getImpactIndex()),
-                new PieChart.Data("Benchmark", 1 - data.getImpactIndex())
+                new PieChart.Data("", 1 - data.getImpactIndex())
         );
         impactChart.setData(impactData);
 
         ObservableList<PieChart.Data> urgencyData = FXCollections.observableArrayList(
                 new PieChart.Data("Urgency Index", data.getUrgencyIndex()),
-                new PieChart.Data("Benchmark", 1 - data.getUrgencyIndex())
+                new PieChart.Data("", 1 - data.getUrgencyIndex())
         );
         urgencyChart.setData(urgencyData);
+
+        reliabilityIndex.setText(String.format("%.2f", (1 - analytics.getPropOverdueLoans()) * 100) + "%");
+        impactIndex.setText(String.format("%.2f", data.getImpactIndex() * 100) + "%");
+        urgencyIndex.setText(String.format("%.2f", data.getUrgencyIndex() * 100) + "%");
     }
 }

--- a/src/main/java/seedu/address/ui/AnalyticsPanel.java
+++ b/src/main/java/seedu/address/ui/AnalyticsPanel.java
@@ -1,12 +1,18 @@
 package seedu.address.ui;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.chart.PieChart;
 import javafx.scene.layout.Region;
+import seedu.address.model.analytics.DashboardData;
 import seedu.address.model.person.Analytics;
+
 
 /**
  * Panel containing the analytics of the loan records.
@@ -15,24 +21,45 @@ public class AnalyticsPanel extends UiPart<Region> {
     private static final String FXML = "AnalyticsPanel.fxml";
 
     @FXML
-    private PieChart pieChart;
+    private PieChart reliabilityChart;
+
+    @FXML
+    private PieChart impactChart;
+
+    @FXML
+    private PieChart urgencyChart;
+
+    private static final float MAX_IMPACT = 1000000;
 
     /**
      * Creates a {@code AnalyticsPanel} with the given {@code ObjectProperty}.
      */
-    public AnalyticsPanel(ObjectProperty<Analytics> analytics) {
+    public AnalyticsPanel(ObjectProperty<DashboardData> dashboardData) {
         super(FXML);
-        pieChart.setData(FXCollections.observableArrayList());
-        analytics.addListener((observable, oldValue, newValue) -> {
+        reliabilityChart.setData(FXCollections.observableArrayList());
+        dashboardData.addListener((observable, oldValue, newValue) -> {
             updateChart(newValue);
         });
     }
 
-    private void updateChart(Analytics analytics) {
-        ObservableList<PieChart.Data> pieChartData = FXCollections.observableArrayList(
+    private void updateChart(DashboardData data) {
+        Analytics analytics = data.getAnalytics();
+        ObservableList<PieChart.Data> reliabilityData = FXCollections.observableArrayList(
                 new PieChart.Data("Active Loans", analytics.getNumActiveLoans()),
-                new PieChart.Data("Overdue Loans", analytics.getNumOverdueLoans())
+                new PieChart.Data("Overdue Loans", analytics.getNumActiveLoans() - analytics.getNumOverdueLoans())
         );
-        pieChart.setData(pieChartData);
+        reliabilityChart.setData(reliabilityData);
+
+        ObservableList<PieChart.Data> impactData = FXCollections.observableArrayList(
+                new PieChart.Data("Impact Index", data.getImpactIndex()),
+                new PieChart.Data("Benchmark", 1 - data.getImpactIndex())
+        );
+        impactChart.setData(impactData);
+
+        ObservableList<PieChart.Data> urgencyData = FXCollections.observableArrayList(
+                new PieChart.Data("Urgency Index", data.getUrgencyIndex()),
+                new PieChart.Data("Benchmark", 1 - data.getUrgencyIndex())
+        );
+        urgencyChart.setData(urgencyData);
     }
 }

--- a/src/main/java/seedu/address/ui/AnalyticsPanel.java
+++ b/src/main/java/seedu/address/ui/AnalyticsPanel.java
@@ -63,9 +63,9 @@ public class AnalyticsPanel extends UiPart<Region> {
         Analytics analytics = data.getAnalytics();
         if (analytics.getNumActiveLoans() == 0) {
             reliabilityIndex.setText("No active loans to analyze");
-            reliabilityChart.setDisable(true);
+            reliabilityChart.setVisible(false);
         } else {
-            reliabilityChart.setDisable(false);
+            reliabilityChart.setVisible(true);
             ObservableList<PieChart.Data> reliabilityData = FXCollections.observableArrayList(
                     new PieChart.Data("Reliability Index", analytics.getPropOverdueLoans()),
                     new PieChart.Data("", 1 - analytics.getPropOverdueLoans())
@@ -77,9 +77,9 @@ public class AnalyticsPanel extends UiPart<Region> {
 
         if (data.getMaxLoanValue() == 0) {
             impactIndex.setText("No loans to analyze");
-            impactChart.setDisable(true);
+            impactChart.setVisible(false);
         } else {
-            impactChart.setDisable(false);
+            impactChart.setVisible(true);
             ObservableList<PieChart.Data> impactData = FXCollections.observableArrayList(
                     new PieChart.Data("Impact Index", data.getImpactIndex()),
                     new PieChart.Data("", 1 - data.getImpactIndex())
@@ -91,9 +91,9 @@ public class AnalyticsPanel extends UiPart<Region> {
 
         if (data.getUrgencyIndex() == null) {
             urgencyIndex.setText("No loans to analyze");
-            urgencyChart.setDisable(true);
+            urgencyChart.setVisible(false);
         } else {
-            urgencyChart.setDisable(false);
+            urgencyChart.setVisible(true);
             ObservableList<PieChart.Data> urgencyData = FXCollections.observableArrayList(
                     new PieChart.Data("Urgency Index", data.getUrgencyIndex()),
                     new PieChart.Data("", 1 - data.getUrgencyIndex())

--- a/src/main/resources/view/AnalyticsPanel.fxml
+++ b/src/main/resources/view/AnalyticsPanel.fxml
@@ -2,8 +2,16 @@
 
 <?import javafx.scene.chart.PieChart?>
 <?import javafx.scene.layout.VBox?>
+<?import javafx.scene.layout.HBox?>
 
 <VBox xmlns:fx="http://javafx.com/fxml" prefHeight="400.0" prefWidth="600.0"
       xmlns="http://javafx.com/javafx/17">
-    <PieChart fx:id="pieChart" layoutX="48.0" layoutY="48.0" prefHeight="304.0" prefWidth="504.0"/>
+    <HBox>
+        <PieChart fx:id="reliabilityChart" layoutX="48.0" layoutY="48.0" prefHeight="304.0" prefWidth="504.0"
+                  HBox.hgrow="ALWAYS"/>
+        <PieChart fx:id="impactChart" layoutX="48.0" layoutY="48.0" prefHeight="304.0" prefWidth="504.0"
+                  HBox.hgrow="ALWAYS"/>
+        <PieChart fx:id="urgencyChart" layoutX="48.0" layoutY="48.0" prefHeight="304.0" prefWidth="504.0"
+                  HBox.hgrow="ALWAYS"/>
+    </HBox>
 </VBox>

--- a/src/main/resources/view/AnalyticsPanel.fxml
+++ b/src/main/resources/view/AnalyticsPanel.fxml
@@ -4,14 +4,30 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.layout.HBox?>
 
+<?import javafx.scene.control.Label?>
 <VBox xmlns:fx="http://javafx.com/fxml" prefHeight="400.0" prefWidth="600.0"
       xmlns="http://javafx.com/javafx/17">
     <HBox>
-        <PieChart fx:id="reliabilityChart" layoutX="48.0" layoutY="48.0" prefHeight="304.0" prefWidth="504.0"
-                  HBox.hgrow="ALWAYS"/>
-        <PieChart fx:id="impactChart" layoutX="48.0" layoutY="48.0" prefHeight="304.0" prefWidth="504.0"
-                  HBox.hgrow="ALWAYS"/>
-        <PieChart fx:id="urgencyChart" layoutX="48.0" layoutY="48.0" prefHeight="304.0" prefWidth="504.0"
-                  HBox.hgrow="ALWAYS"/>
+        <VBox alignment="CENTER" HBox.hgrow="ALWAYS">
+            <Label style="-fx-text-fill: white">Reliability</Label>
+            <PieChart fx:id="reliabilityChart" layoutX="48.0" layoutY="48.0" prefHeight="200.0" prefWidth="200"
+                      HBox.hgrow="ALWAYS"/>
+            <Label fx:id="reliabilityIndex" style="-fx-text-fill: white;"/>
+        </VBox>
+
+        <VBox alignment="CENTER" HBox.hgrow="ALWAYS">
+            <Label style="-fx-text-fill: white">Impact</Label>
+            <PieChart fx:id="impactChart" layoutX="48.0" layoutY="48.0" prefHeight="200.0" prefWidth="200"
+                      HBox.hgrow="ALWAYS"/>
+            <Label fx:id="impactIndex" style="-fx-text-fill: white;"/>
+        </VBox>
+
+        <VBox alignment="CENTER" HBox.hgrow="ALWAYS">
+            <Label style="-fx-text-fill: white">Urgency</Label>
+            <PieChart fx:id="urgencyChart" layoutX="48.0" layoutY="48.0" prefHeight="200.0" prefWidth="200"
+                      HBox.hgrow="ALWAYS"/>
+            <Label fx:id="urgencyIndex" style="-fx-text-fill: white;"/>
+        </VBox>
+
     </HBox>
 </VBox>

--- a/src/main/resources/view/AnalyticsPanel.fxml
+++ b/src/main/resources/view/AnalyticsPanel.fxml
@@ -28,6 +28,5 @@
                       HBox.hgrow="ALWAYS"/>
             <Label fx:id="urgencyIndex" style="-fx-text-fill: white;"/>
         </VBox>
-
     </HBox>
 </VBox>

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -200,11 +200,6 @@ public class AddCommandTest {
         }
 
         @Override
-        public void setDashboardData(DashboardData data) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
         public ObjectProperty<DashboardData> getDashboardData() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -25,6 +25,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.analytics.DashboardData;
 import seedu.address.model.person.Analytics;
 import seedu.address.model.person.Loan;
 import seedu.address.model.person.Person;
@@ -199,12 +200,12 @@ public class AddCommandTest {
         }
 
         @Override
-        public void setAnalytics(Analytics analytics) {
+        public void setDashboardData(DashboardData data) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public ObjectProperty<Analytics> getAnalytics() {
+        public ObjectProperty<DashboardData> getDashboardData() {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -235,6 +236,11 @@ public class AddCommandTest {
 
         @Override
         public void setToPersonTab() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void generateDashboardData(Analytics analytics) {
             throw new AssertionError("This method should not be called.");
         }
 


### PR DESCRIPTION
Resolves #84 

### Feature added

A GUI display for analytics has been implemented. It showcases 3 values in piecharts - Reliability, Impact and Urgency

<img width="739" alt="Screenshot 2024-04-03 at 3 16 15 AM" src="https://github.com/AY2324S2-CS2103T-W13-1/tp/assets/117426083/29fe17d3-e014-4b8e-baa9-e0a14429c724">

### Changelog

- New class `DashboardData` has been added to encapsulate current contact's analytics and the max values of all existing loans. These max values are used for reference in calculating Impact and Urgency indices

### Notes

- Help wanted to test out possible issues with the RIU indices as this feature may be bug prone depending on existence/absence of certain values
- For any non-functional issues related to GUI cosmetics (boxes stretching incorrectly, color schemes, etc.), please help to add comments into issue #98

##### Currently handled cases
- no active loans > reliability pie chart should NOT show. Instead, a message at the bottom will be displayed saying "No active loans to analyze"
- no active loans that are due in the future > earliest return date will be null for that person's analytics(?). The piechart for Urgency should not show. Instead, a message at the bottom will be displayed saying "No active loans to analyze"
- no loans in history > impact chart should not show


