### PR TITLE
Update success message after a linkloan command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/LinkLoanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LinkLoanCommand.java
@@ -15,6 +15,7 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.Loan;
 import seedu.address.model.person.Person;
 
 /**
@@ -37,7 +38,8 @@ public class LinkLoanCommand extends Command {
             + PREFIX_START_DATE + "2024-02-15 "
             + PREFIX_RETURN_DATE + "2024-04-21";
 
-    public static final String MESSAGE_SUCCESS = "New loan linked: %1$s";
+    public static final String MESSAGE_SUCCESS = "New loan linked to: %1$s\n"
+            + "%2$s";
 
     private final LinkLoanDescriptor toLink;
 
@@ -66,9 +68,10 @@ public class LinkLoanCommand extends Command {
 
         Person targetPerson = lastShownList.get(linkTarget.getZeroBased());
 
-        model.addLoan(toLink, targetPerson);
+        Loan linkedLoan = model.addLoan(toLink, targetPerson);
 
-        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(targetPerson)));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, targetPerson.getName(),
+                linkedLoan));
     }
 
     @Override


### PR DESCRIPTION
Fixes #96.

Now when a `linkloan` command is executed, the person name will be shown, followed by the loan details in the next line.
E.g.
```
New loan linked to: John Lee
$500.00, 2024-01-02, 2024-03-01
```