### PR TITLE
Fix gap in GUI when `viewloan <index>` is called

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -65,7 +65,7 @@ public interface Logic {
 
     BooleanProperty getIsAnalyticsTab();
 
-    void setToPersonTab();
-
     ObjectProperty<DashboardData> getAnalytics();
+
+    BooleanProperty getIsPersonTab();
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -121,7 +121,7 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public void setToPersonTab() {
-        model.setToPersonTab();
+    public BooleanProperty getIsPersonTab() {
+        return model.getIsPersonTab();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ViewLoanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewLoanCommand.java
@@ -50,6 +50,7 @@ public class ViewLoanCommand extends ViewLoanRelatedCommand {
         } else {
             model.updateFilteredLoanList(loan -> loan.isAssignedTo(personToShowLoan) && loan.isActive());
         }
+        model.setDualPanel();
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(personToShowLoan)),
                 false, false, true);
     }

--- a/src/main/java/seedu/address/logic/commands/ViewLoansCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewLoansCommand.java
@@ -28,6 +28,7 @@ public class ViewLoansCommand extends ViewLoanRelatedCommand {
         } else {
             model.updateFilteredLoanList(PREDICATE_SHOW_ALL_ACTIVE_LOANS);
         }
+        model.setIsLoansTab(true);
         return new CommandResult(MESSAGE_SUCCESS, false, false, true);
     }
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -156,4 +156,10 @@ public interface Model {
     void unmarkLoan(Loan loanToUnmark);
 
     ObjectProperty<DashboardData> getDashboardData();
+
+    BooleanProperty getIsPersonTab();
+
+    void setIsPersonTab(Boolean isPersonTab);
+
+    void setDualPanel();
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -221,8 +221,10 @@ public class ModelManager implements Model {
 
     @Override
     public void setIsLoansTab(Boolean isLoansTab) {
+        System.out.println("Method setIsLoansTab called inside ModelManager");
         if (isLoansTab) {
             this.isAnalyticsTab.setValue(false);
+            this.isPersonTab.setValue(false);
         }
         this.isLoansTab.setValue(isLoansTab);
     }
@@ -234,14 +236,17 @@ public class ModelManager implements Model {
 
     @Override
     public void setToPersonTab() {
+        System.out.println("Method setToPersonTab called inside ModelManager");
         this.isLoansTab.setValue(false);
         this.isAnalyticsTab.setValue(false);
+        this.setIsPersonTab(true);
     }
 
     @Override
     public void setIsAnalyticsTab(Boolean isAnalyticsTab) {
         if (isAnalyticsTab) {
             this.isLoansTab.setValue(false);
+            this.isPersonTab.setValue(false);
         }
         this.isAnalyticsTab.setValue(isAnalyticsTab);
     }
@@ -265,6 +270,7 @@ public class ModelManager implements Model {
 
     @Override
     public void setIsPersonTab(Boolean isPersonTab) {
+        System.out.println("Method setIsPersonTab called inside ModelManager");
         if (isPersonTab) {
             this.isLoansTab.setValue(false);
             this.isAnalyticsTab.setValue(false);
@@ -274,6 +280,7 @@ public class ModelManager implements Model {
 
     @Override
     public void setDualPanel() {
+        System.out.println("Method setDualPanel called inside ModelManager");
         this.isLoansTab.setValue(true);
         this.isPersonTab.setValue(true);
         this.isAnalyticsTab.setValue(false);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -37,6 +37,7 @@ public class ModelManager implements Model {
     private final SortedList<Loan> sortedLoans;
     private final BooleanProperty isLoansTab = new SimpleBooleanProperty(false);
     private final BooleanProperty isAnalyticsTab = new SimpleBooleanProperty(false);
+    private final BooleanProperty isPersonTab = new SimpleBooleanProperty(false);
     private final ObjectProperty<DashboardData> dashboardData = new SimpleObjectProperty<>();
 
     /**
@@ -255,5 +256,26 @@ public class ModelManager implements Model {
         float impactBenchmark = this.addressBook.getUniqueLoanList().getMaxLoanValue();
         Date urgencyBenchmark = this.addressBook.getUniqueLoanList().getEarliestReturnDate();
         dashboardData.setValue(new DashboardData(analytics, impactBenchmark, urgencyBenchmark));
+    }
+
+    @Override
+    public BooleanProperty getIsPersonTab() {
+        return this.isPersonTab;
+    }
+
+    @Override
+    public void setIsPersonTab(Boolean isPersonTab) {
+        if (isPersonTab) {
+            this.isLoansTab.setValue(false);
+            this.isAnalyticsTab.setValue(false);
+        }
+        this.isPersonTab.setValue(isPersonTab);
+    }
+
+    @Override
+    public void setDualPanel() {
+        this.isLoansTab.setValue(true);
+        this.isPersonTab.setValue(true);
+        this.isAnalyticsTab.setValue(false);
     }
 }

--- a/src/main/java/seedu/address/ui/LoanListPanel.java
+++ b/src/main/java/seedu/address/ui/LoanListPanel.java
@@ -31,8 +31,8 @@ public class LoanListPanel extends UiPart<Region> {
         super(FXML);
         loanListView.setItems(loanList);
         loanListView.setCellFactory(listView -> new LoanListViewCell());
-        personListView.setItems(personList);
-        personListView.setCellFactory(listView -> new PersonListViewCell());
+//        personListView.setItems(personList);
+//        personListView.setCellFactory(listView -> new PersonListViewCell());
     }
 
     /**

--- a/src/main/java/seedu/address/ui/LoanListPanel.java
+++ b/src/main/java/seedu/address/ui/LoanListPanel.java
@@ -31,8 +31,6 @@ public class LoanListPanel extends UiPart<Region> {
         super(FXML);
         loanListView.setItems(loanList);
         loanListView.setCellFactory(listView -> new LoanListViewCell());
-//        personListView.setItems(personList);
-//        personListView.setCellFactory(listView -> new PersonListViewCell());
     }
 
     /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -75,6 +75,8 @@ public class MainWindow extends UiPart<Stage> {
 
     private BooleanProperty isAnalyticsTab;
 
+    private BooleanProperty isPersonTab;
+
     /**
      * Creates a {@code MainWindow} with the given {@code Stage} and {@code Logic}.
      */
@@ -167,8 +169,13 @@ public class MainWindow extends UiPart<Stage> {
         this.isLoansTab = logic.getIsLoansTab();
         // Add listener to update the analytics panel when the tab is switched
         this.isAnalyticsTab = logic.getIsAnalyticsTab();
+        this.isPersonTab = logic.getIsPersonTab();
         logic.setIsAnalyticsTab(false);
         logic.setIsLoansTab(false);
+
+        this.isPersonTab.addListener((observable, oldValue, newValue) -> {
+            toggleTabs();
+        });
         this.isLoansTab.addListener((observable, oldValue, newValue) -> {
             toggleTabs();
         });
@@ -179,9 +186,19 @@ public class MainWindow extends UiPart<Stage> {
 
     private void toggleTabs() {
         // At most one can be active at a time
-        assert (!(this.isLoansTab.getValue() && this.isAnalyticsTab.getValue()));
+        // assert (!(this.isLoansTab.getValue() && this.isAnalyticsTab.getValue()));
 
-        if (!this.isLoansTab.getValue() && !this.isAnalyticsTab.getValue()) {
+        if (isPersonTab.getValue() && isLoansTab.getValue()) {
+            // Default to person list panel
+            clearAllPlaceholders();
+            VBox.setVgrow(personList, Priority.ALWAYS);
+            VBox.setVgrow(loanList, Priority.NEVER);
+            VBox.setVgrow(analytics, Priority.NEVER);
+            personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
+            VBox.setVgrow(loanList, Priority.ALWAYS);
+            loanListPanelPlaceholder.getChildren().add(loanListPanel.getRoot());
+            VBox.setVgrow(analytics, Priority.NEVER);
+        } else if (isPersonTab.getValue()) {
             // Default to person list panel
             clearAllPlaceholders();
             VBox.setVgrow(personList, Priority.ALWAYS);

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -185,9 +185,8 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     private void toggleTabs() {
-        // At most one can be active at a time
-        // assert (!(this.isLoansTab.getValue() && this.isAnalyticsTab.getValue()));
-
+        // At most one of these can be active at a time
+        assert (!(this.isLoansTab.getValue() && this.isAnalyticsTab.getValue()));
         if (isPersonTab.getValue() && isLoansTab.getValue()) {
             // Default to person list panel
             clearAllPlaceholders();
@@ -198,19 +197,24 @@ public class MainWindow extends UiPart<Stage> {
             VBox.setVgrow(loanList, Priority.ALWAYS);
             loanListPanelPlaceholder.getChildren().add(loanListPanel.getRoot());
             VBox.setVgrow(analytics, Priority.NEVER);
+            personListPanelPlaceholder.setMaxHeight(240);
+            System.out.println("Both tabs are active");
         } else if (isPersonTab.getValue()) {
             // Default to person list panel
             clearAllPlaceholders();
+            personListPanelPlaceholder.setMaxHeight(Double.POSITIVE_INFINITY);
             VBox.setVgrow(personList, Priority.ALWAYS);
             VBox.setVgrow(loanList, Priority.NEVER);
             VBox.setVgrow(analytics, Priority.NEVER);
             personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
+            System.out.println("Only person tab is active");
         } else if (this.isLoansTab.getValue()) {
             clearAllPlaceholders();
             VBox.setVgrow(loanList, Priority.ALWAYS);
             VBox.setVgrow(personList, Priority.NEVER);
             VBox.setVgrow(analytics, Priority.NEVER);
             loanListPanelPlaceholder.getChildren().add(loanListPanel.getRoot());
+            System.out.println("Only loans tab is active");
         } else {
             clearAllPlaceholders();
             VBox.setVgrow(analytics, Priority.ALWAYS);
@@ -293,7 +297,7 @@ public class MainWindow extends UiPart<Stage> {
                 handleExit();
             }
             // Enable/Disable the loan tab based on whether command is loan related
-            logic.setIsLoansTab(commandResult.isLoanRelated());
+            // logic.setIsLoansTab(commandResult.isLoanRelated());
 
             return commandResult;
         } catch (CommandException | ParseException e) {

--- a/src/main/resources/view/LoanListPanel.fxml
+++ b/src/main/resources/view/LoanListPanel.fxml
@@ -4,6 +4,5 @@
 <?import javafx.scene.layout.VBox?>
 
 <VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" spacing="0">
-    <ListView fx:id="personListView" maxHeight="290"/>
     <ListView fx:id="loanListView" VBox.vgrow="ALWAYS"/>
 </VBox>

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -198,6 +198,7 @@ public class AddCommandTest {
         public void markLoan(Loan loanToMark) {
             throw new AssertionError("This method should not be called.");
         }
+
         @Override
         public void unmarkLoan(Loan loanToUnmark) {
             throw new AssertionError("This method should not be called.");

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -210,6 +210,21 @@ public class AddCommandTest {
         }
 
         @Override
+        public BooleanProperty getIsPersonTab() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setIsPersonTab(Boolean isPersonTab) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setDualPanel() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void deleteLoan(Loan loan) {
             throw new AssertionError("This method should not be called.");
         }


### PR DESCRIPTION
Fixes #98 

### Changelog

- Implement an extra setting in `Model` to allow for dual panel view
- New variable `isPersonTab` added to `Model`. Since these BooleanProperties are becoming repetitive, we can refactor this by encapsulating all these tab properties into a single object in the coming interations

Note:

Seems to have fixed #106 as well (visually on the GUI). need confirming and testing. Likely will need more changes for this since the background list might still be populated when it shouldn't be.