### PR TITLE
Implement defensive command access

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -61,6 +61,7 @@ public class MainApp extends Application {
         storage = new StorageManager(addressBookStorage, userPrefsStorage);
 
         model = initModelManager(storage, userPrefs);
+        model.updateFilteredLoanList(Model.PREDICATE_SHOW_NO_LOANS);
 
         logic = new LogicManager(model, storage);
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -42,6 +42,7 @@ public class DeleteCommand extends Command {
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(personToDelete);
+        model.setToPersonTab();
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/ViewLoansCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewLoansCommand.java
@@ -3,7 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_ACTIVE_LOANS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_LOANS;
-import static seedu.address.model.Model.PREDICATE_SHOW_NO_PERSON;
+import static seedu.address.model.Model.PREDICATE_SHOW_NO_PERSONS;
 
 import seedu.address.model.Model;
 
@@ -22,7 +22,7 @@ public class ViewLoansCommand extends ViewLoanRelatedCommand {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(PREDICATE_SHOW_NO_PERSON);
+        model.updateFilteredPersonList(PREDICATE_SHOW_NO_PERSONS);
         if (isShowAllLoans) {
             model.updateFilteredLoanList(PREDICATE_SHOW_ALL_LOANS);
         } else {

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -26,7 +26,7 @@ public interface Model {
     /**
      * {@code Predicate} that always evaluates to false
      */
-    Predicate<Person> PREDICATE_SHOW_NO_PERSON = unused -> false;
+    Predicate<Person> PREDICATE_SHOW_NO_PERSONS = unused -> false;
 
     /**
      * {@code Predicate} that always evaluate to true
@@ -37,6 +37,11 @@ public interface Model {
      * {@code Predicate} that evaluates to true if the loan is active
      */
     Predicate<Loan> PREDICATE_SHOW_ALL_ACTIVE_LOANS = loan -> loan.isActive();
+
+    /**
+     * {@code Predicate} that always evaluates to false
+     */
+    Predicate<Loan> PREDICATE_SHOW_NO_LOANS = unused -> false;
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -239,6 +239,7 @@ public class ModelManager implements Model {
         System.out.println("Method setToPersonTab called inside ModelManager");
         this.isLoansTab.setValue(false);
         this.isAnalyticsTab.setValue(false);
+        this.updateFilteredLoanList(PREDICATE_SHOW_NO_LOANS);
         this.setIsPersonTab(true);
     }
 
@@ -247,6 +248,8 @@ public class ModelManager implements Model {
         if (isAnalyticsTab) {
             this.isLoansTab.setValue(false);
             this.isPersonTab.setValue(false);
+            this.updateFilteredPersonList(PREDICATE_SHOW_NO_PERSONS);
+            this.updateFilteredLoanList(PREDICATE_SHOW_NO_LOANS);
         }
         this.isAnalyticsTab.setValue(isAnalyticsTab);
     }


### PR DESCRIPTION
Fix #98 and #110.

**Defensive command access** is implemented with the following features:
- On person tab: No access to loan commands based on loan index.
- On view all loans tab: No access to person commands based on person index.
- On view loan of a person tab: Can only modify the person whose loan is being shown
- On analytics tab: No access to loan and person commands based on index.

**Special case:**
When one `viewloan` a person and `delete` the person on that tab, one is redirected to the person tab with an empty list of persons. This modelled on the case when `find` only returns one person: If one `delete` this person, the person list will be blank.