### PR TITLE
Fix behaviour of edit person in loan view

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
 import java.util.HashSet;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -84,7 +84,10 @@ public class EditCommand extends Command {
         }
 
         model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        if (model.getIsLoansTab().get()) {
+            model.updateFilteredPersonList(person -> person.isSamePerson(editedPerson));
+            model.updateFilteredLoanList(loan -> loan.isAssignedTo(editedPerson));
+        }
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/ViewLoanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewLoanCommand.java
@@ -45,11 +45,7 @@ public class ViewLoanCommand extends ViewLoanRelatedCommand {
 
         Person personToShowLoan = lastShownList.get(targetIndex.getZeroBased());
         model.updateFilteredPersonList(person -> person.equals(personToShowLoan));
-        if (isShowAllLoans) {
-            model.updateFilteredLoanList(loan -> loan.isAssignedTo(personToShowLoan));
-        } else {
-            model.updateFilteredLoanList(loan -> loan.isAssignedTo(personToShowLoan) && loan.isActive());
-        }
+        model.updateFilteredLoanList(loan -> loan.isAssignedTo(personToShowLoan), isShowAllLoans);
         model.setDualPanel();
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(personToShowLoan)),
                 false, false, true);

--- a/src/main/java/seedu/address/logic/commands/ViewLoansCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewLoansCommand.java
@@ -1,8 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_ACTIVE_LOANS;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_LOANS;
 import static seedu.address.model.Model.PREDICATE_SHOW_NO_PERSONS;
 
 import seedu.address.model.Model;

--- a/src/main/java/seedu/address/logic/commands/ViewLoansCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewLoansCommand.java
@@ -23,11 +23,7 @@ public class ViewLoansCommand extends ViewLoanRelatedCommand {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_NO_PERSONS);
-        if (isShowAllLoans) {
-            model.updateFilteredLoanList(PREDICATE_SHOW_ALL_LOANS);
-        } else {
-            model.updateFilteredLoanList(PREDICATE_SHOW_ALL_ACTIVE_LOANS);
-        }
+        model.updateFilteredLoanList(unused -> true, isShowAllLoans);
         model.setIsLoansTab(true);
         return new CommandResult(MESSAGE_SUCCESS, false, false, true);
     }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -138,10 +138,25 @@ public interface Model {
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
 
+    /**
+     * Returns an unmodifiable view of the sorted loan list
+     */
     ObservableList<Loan> getSortedLoanList();
 
+    /**
+     * Updates the filter of the filtered loan list to filter by the given {@code predicate}.
+     *
+     * @param predicate
+     */
     void updateFilteredLoanList(Predicate<Loan> predicate);
 
+    /**
+     * Updates the filter of the filtered loan list to filter by the given {@code predicate}.
+     * Also updates the preference of whether to show all loans or only active loans.
+     *
+     * @param predicate
+     * @param isShowAllLoans
+     */
     void updateFilteredLoanList(Predicate<Loan> predicate, boolean isShowAllLoans);
 
     void setLoanList(List<Loan> loanList);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -142,6 +142,8 @@ public interface Model {
 
     void updateFilteredLoanList(Predicate<Loan> predicate);
 
+    void updateFilteredLoanList(Predicate<Loan> predicate, boolean isShowAllLoans);
+
     void setLoanList(List<Loan> loanList);
 
     BooleanProperty getIsLoansTab();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -38,6 +38,7 @@ public class ModelManager implements Model {
     private final BooleanProperty isLoansTab = new SimpleBooleanProperty(false);
     private final BooleanProperty isAnalyticsTab = new SimpleBooleanProperty(false);
     private final BooleanProperty isPersonTab = new SimpleBooleanProperty(false);
+    private final BooleanProperty isShowAllLoans = new SimpleBooleanProperty(false);
     private final ObjectProperty<DashboardData> dashboardData = new SimpleObjectProperty<>();
 
     /**
@@ -187,7 +188,16 @@ public class ModelManager implements Model {
     @Override
     public void updateFilteredLoanList(Predicate<Loan> predicate) {
         requireNonNull(predicate);
-        filteredLoans.setPredicate(predicate);
+        Predicate<Loan> second_predicate =
+                isShowAllLoans.get() ? PREDICATE_SHOW_ALL_LOANS : PREDICATE_SHOW_ALL_ACTIVE_LOANS;
+        filteredLoans.setPredicate(predicate.and(second_predicate));
+    }
+
+    @Override
+    public void updateFilteredLoanList(Predicate<Loan> predicate, boolean isShowAllLoans) {
+        requireNonNull(predicate);
+        this.isShowAllLoans.setValue(isShowAllLoans);
+        updateFilteredLoanList(predicate);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -169,6 +169,8 @@ public class AddCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
+
+
         @Override
         public void setLoanList(List<Loan> loanList) {
             throw new AssertionError("This method should not be called.");
@@ -181,6 +183,11 @@ public class AddCommandTest {
 
         @Override
         public void updateFilteredLoanList(Predicate<Loan> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredLoanList(Predicate<Loan> predicate, boolean isShowAllLoans) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -84,8 +84,6 @@ public class EditCommandTest {
 
     @Test
     public void execute_filteredList_success() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
-
         Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person editedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,


### PR DESCRIPTION
Fix #120.

**Behaviour changes:**
When calling `edit` in loan view, the only things changed in GUI are the edited fields.

**Code changes:**
- Create new boolean property in `ModelManager` called `isShownAllLoans`.
- Refactor and overload `ModelManager.updateFilteredLoanList()`.
- Change `viewloan` and `edit` to reflect the changes.