### PR TITLE
Fix stretching personList on dual panel display

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -206,7 +206,10 @@ public class MainWindow extends UiPart<Stage> {
             VBox.setVgrow(loanList, Priority.ALWAYS);
             loanListPanelPlaceholder.getChildren().add(loanListPanel.getRoot());
             VBox.setVgrow(analytics, Priority.NEVER);
-            personListPanelPlaceholder.setMaxHeight(240);
+            personListPanelPlaceholder.setMaxHeight(105);
+            personListPanelPlaceholder.setMinHeight(105);
+            VBox.setVgrow(personList, Priority.NEVER);
+
             System.out.println("Both tabs are active");
         } else if (isPersonTab.getValue()) {
             // Default to person list panel
@@ -223,12 +226,14 @@ public class MainWindow extends UiPart<Stage> {
             VBox.setVgrow(personList, Priority.NEVER);
             VBox.setVgrow(analytics, Priority.NEVER);
             loanListPanelPlaceholder.getChildren().add(loanListPanel.getRoot());
+            personListPanelPlaceholder.setMinHeight(0);
             System.out.println("Only loans tab is active");
         } else {
             clearAllPlaceholders();
             VBox.setVgrow(analytics, Priority.ALWAYS);
             VBox.setVgrow(personList, Priority.NEVER);
             VBox.setVgrow(loanList, Priority.NEVER);
+            personListPanelPlaceholder.setMinHeight(0);
             analyticsPanelPlaceholder.getChildren().add(analyticsPanel.getRoot());
         }
     }

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -47,16 +47,16 @@
 
                 <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="340"
                       VBox.vgrow="ALWAYS">
-                    <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="NEVER"/>
+                    <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
                 </VBox>
 
                 <VBox fx:id="analytics" styleClass="pane-with-border" minWidth="340" prefWidth="340"
                       VBox.vgrow="ALWAYS">
-                    <StackPane fx:id="analyticsPanelPlaceholder" VBox.vgrow="NEVER"/>
+                    <StackPane fx:id="analyticsPanelPlaceholder" VBox.vgrow="ALWAYS"/>
                 </VBox>
 
                 <VBox fx:id="loanList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
-                    <StackPane fx:id="loanListPanelPlaceholder" VBox.vgrow="NEVER"/>
+                    <StackPane fx:id="loanListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
                 </VBox>
                 <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER"/>
             </VBox>


### PR DESCRIPTION
Fixes an issue where the person list panel and loan list panel are counted as flex boxes and take up equal space instead of the singular person card having fixed space.