### PR TITLE
Fail gracefully upon loan storage tampering

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -85,6 +85,14 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Returns true if a person with the same identity as {@code person} exists in the address book.
+     */
+    public boolean hasExactPerson(Person person) {
+        requireNonNull(person);
+        return persons.containsExact(person);
+    }
+
+    /**
      * Adds a person to the address book.
      * The person must not already exist in the address book.
      */

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -37,6 +37,14 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
+     * Returns true if the list contains an exact person as the given argument.
+     */
+    public boolean containsExact(Person person) {
+        requireNonNull(person);
+        return internalList.stream().anyMatch(person::equals);
+    }
+
+    /**
      * Adds a person to the list.
      * The person must not already exist in the list.
      */

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -66,7 +66,7 @@ class JsonSerializableAddressBook {
             if (addressBook.hasLoan(loan)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_LOAN);
             }
-            if (!addressBook.hasPerson(loan.getAssignee())) {
+            if (!addressBook.hasExactPerson(loan.getAssignee())) {
                 throw new IllegalValueException(MESSAGE_ORPHAN_LOAN);
             }
             addressBook.addLoan(loan);

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.person.Loan;
 import seedu.address.model.person.Person;
 
 /**
@@ -20,6 +21,8 @@ import seedu.address.model.person.Person;
 class JsonSerializableAddressBook {
 
     public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
+    public static final String MESSAGE_DUPLICATE_LOAN = "Loans list contains duplicate loan id(s).";
+    public static final String MESSAGE_ORPHAN_LOAN = "Loans list contains loan(s) with no associated person.";
 
     private final List<JsonAdaptedPerson> persons = new ArrayList<>();
     private final List<JsonAdaptedLoan> loans = new ArrayList<>();
@@ -59,7 +62,14 @@ class JsonSerializableAddressBook {
             addressBook.addPerson(person);
         }
         for (JsonAdaptedLoan jsonAdaptedLoan : loans) {
-            addressBook.addLoan(jsonAdaptedLoan.toModelType());
+            Loan loan = jsonAdaptedLoan.toModelType();
+            if (addressBook.hasLoan(loan)) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_LOAN);
+            }
+            if (!addressBook.hasPerson(loan.getAssignee())) {
+                throw new IllegalValueException(MESSAGE_ORPHAN_LOAN);
+            }
+            addressBook.addLoan(loan);
         }
         return addressBook;
     }


### PR DESCRIPTION
Fix #174. Fix #150. Fix #139.

**Behaviour change:**

- If two stored loans have the same id, start with a blank address book.
- If loan has an assignee not in the address book, start with a blank address book.

**Implementation change:**

- Because `AddressBook.hasPerson()` and `UniquePersonList.contains()` only checks for names, so they are not suitable for the above.
  - Otherwise, the app may successfully boot despite the loan having an assignee with the same name but different other fields.
- Therefore, `AddressBook.hasExactPerson()` and `UniquePersonList.containsExact()` are implemented to make this work.