### PR TITLE
Remove time from being displayed in loan start and return dates

### DIFF
--- a/src/main/java/seedu/address/ui/LoanCard.java
+++ b/src/main/java/seedu/address/ui/LoanCard.java
@@ -5,6 +5,7 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
+import seedu.address.commons.util.DateUtil;
 import seedu.address.model.person.Loan;
 
 /**
@@ -57,8 +58,8 @@ public class LoanCard extends UiPart<Region> {
         this.loan = loan;
         name.setText(DEFAULT_LOAN_PREFIX + displayedIndex);
         amount.setText(DEFAULT_AMOUNT_PREFIX + String.valueOf(loan.getValue()));
-        startDate.setText(DEFAULT_START_DATE_PREFIX + loan.getStartDate().toString());
-        endDate.setText(DEFAULT_END_DATE_PREFIX + loan.getReturnDate().toString());
+        startDate.setText(DEFAULT_START_DATE_PREFIX + DateUtil.format(loan.getStartDate()));
+        endDate.setText(DEFAULT_END_DATE_PREFIX + DateUtil.format(loan.getReturnDate()));
         returned.setText(DEFAULT_RETURNED_STATUS_PREFIX + (loan.isReturned() ? "Yes" : "No"));
         if (showLoanee) {
             loanee.setText("Loanee: " + loan.getAssignee().getName());


### PR DESCRIPTION
Fixes #154.

Originally, all loans added were being shown as having a deadline of midnight on the dates they were assigned, even though loans are not intended to have a time.

Behaviour was problematic as if a user originally intended a loan to be returned by date X (e.g. `2024-12-31`), LoanGuard Pro would record the deadline as midnight on date X. 

This would lead the user to believe that if the loan was returned on date X, it would be late, although the loan is not late due to the deadline being date X.

For instance, the loan being returned on `2024-12-31 14:00` would not be late, but the way LoanGuard Pro displayed the loan return date as `2024-12-31 00:00` might lead the user to believe that it was late.