### PR TITLE
Add missing analytics message usage

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AnalyticsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AnalyticsCommand.java
@@ -18,6 +18,12 @@ import seedu.address.model.person.Person;
 public class AnalyticsCommand extends Command {
     public static final String COMMAND_WORD = "analytics";
 
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Displays the analytics of the person "
+            + "identified by the index number used in the displayed person list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
     public static final String MESSAGE_SUCCESS = "Analytics generated";
     private final Index targetIndex;
 

--- a/src/main/java/seedu/address/logic/parser/AnalyticsCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AnalyticsCommandParser.java
@@ -23,7 +23,7 @@ public class AnalyticsCommandParser implements Parser<AnalyticsCommand> {
             return new AnalyticsCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(
-                    MESSAGE_INVALID_COMMAND_FORMAT, pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, AnalyticsCommand.MESSAGE_USAGE), pe);
         }
     }
 


### PR DESCRIPTION
Fixes #129.

Adds a `MESSAGE_USAGE` for the analytics command (i.e. the message showing the user how to use the analytics command properly).

Now, error messages for invalid `analytics` commands will have this form:

```
Invalid command format! 
analytics: Displays the analytics of the person identified by the index number used in the displayed person list.
Parameters: INDEX (must be a positive integer)
Example: analytics 1
```

This is similar to the format of error messages for other commands.