### PR TITLE
Fix bug causing urgency to return negative values

### DIFF
--- a/src/main/java/seedu/address/model/analytics/DashboardData.java
+++ b/src/main/java/seedu/address/model/analytics/DashboardData.java
@@ -64,11 +64,15 @@ public class DashboardData {
         if (analytics.getEarliestReturnDate() == null || earliestReturnDate == null) {
             return null;
         }
+
         LocalDate target = analytics.getEarliestReturnDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
         LocalDate benchmark = this.earliestReturnDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
         LocalDate now = LocalDate.now();
         long dayDiffBenchmark = benchmark.toEpochDay() - now.toEpochDay();
         long dayDiffTarget = target.toEpochDay() - now.toEpochDay();
+        if (dayDiffTarget == 0) {
+            return 1.0f;
+        }
         return (float) dayDiffBenchmark / dayDiffTarget;
     }
 

--- a/src/main/java/seedu/address/model/person/Analytics.java
+++ b/src/main/java/seedu/address/model/person/Analytics.java
@@ -27,7 +27,7 @@ public class Analytics {
     private BigDecimal averageActiveValue; // average loan value of all active loans
 
     private Date earliestLoanDate; // earliest loan date of all loans
-    private Date earliestReturnDate; // earliest return date of active loans
+    private Date earliestReturnDate; // earliest return date of active loans (not overdue)
     private Date latestLoanDate; // latest loan date of all loans
     private Date latestReturnDate; // latest return date of active loans
 
@@ -125,7 +125,7 @@ public class Analytics {
         if (this.latestLoanDate == null || loan.getStartDate().after(this.latestLoanDate)) {
             this.latestLoanDate = loan.getStartDate();
         }
-        if (!loan.isReturned()) {
+        if (!loan.isReturned() && !loan.isOverdue()) {
             if (this.earliestReturnDate == null || loan.getReturnDate().before(this.earliestReturnDate)) {
                 this.earliestReturnDate = loan.getReturnDate();
             }
@@ -133,6 +133,7 @@ public class Analytics {
                 this.latestReturnDate = loan.getReturnDate();
             }
         }
+
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/UniqueLoanList.java
+++ b/src/main/java/seedu/address/model/person/UniqueLoanList.java
@@ -355,7 +355,6 @@ public class UniqueLoanList implements Iterable<Loan> {
         for (Loan loan : internalList) {
             if ((earliestReturnDate == null || loan.getReturnDate().before(earliestReturnDate))
                     && !loan.isOverdue() && !loan.isReturned()) {
-                System.out.println(loan.getReturnDate() + " " + loan.isOverdue() + " " + loan.isReturned());
                 earliestReturnDate = loan.getReturnDate();
             }
         }

--- a/src/main/java/seedu/address/model/person/UniqueLoanList.java
+++ b/src/main/java/seedu/address/model/person/UniqueLoanList.java
@@ -218,6 +218,7 @@ public class UniqueLoanList implements Iterable<Loan> {
 
     /**
      * Unmarks a loan.
+     *
      * @param loanToUnmark A valid loan.
      */
     public void unmarkLoan(Loan loanToUnmark) {
@@ -353,7 +354,8 @@ public class UniqueLoanList implements Iterable<Loan> {
         Date earliestReturnDate = null;
         for (Loan loan : internalList) {
             if ((earliestReturnDate == null || loan.getReturnDate().before(earliestReturnDate))
-                    && !loan.getReturnDate().before(new Date()) && !loan.isReturned()) {
+                    && !loan.isOverdue() && !loan.isReturned()) {
+                System.out.println(loan.getReturnDate() + " " + loan.isOverdue() + " " + loan.isReturned());
                 earliestReturnDate = loan.getReturnDate();
             }
         }


### PR DESCRIPTION
Fixes #130 

## Changelog

- in `UniqueLoanList`, the `getEarliestReturnDate` method now uses `loan.isOverdue` instead of manual calculation to filter out overdue loans
- In `Analytics`, the `EarliestReturnDate` attribute has been modified to not reflect overdue ones