### PR TITLE
Add test cases for loan-related commands

### DIFF
--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -9,11 +9,15 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.commons.util.DateUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
@@ -26,6 +30,30 @@ import seedu.address.testutil.EditPersonDescriptorBuilder;
  */
 public class CommandTestUtil {
 
+    public static final BigDecimal VALID_LOAN_VALUE_ONE = new BigDecimal("500.00");
+    public static final BigDecimal VALID_LOAN_VALUE_TWO = new BigDecimal("42.67");
+    public static final BigDecimal VALID_LOAN_VALUE_THREE = new BigDecimal("0.01");
+    public static final Date VALID_LOAN_START_DATE_ONE;
+    public static final Date VALID_LOAN_START_DATE_TWO;
+    public static final Date VALID_LOAN_START_DATE_THREE;
+
+    public static final Date VALID_LOAN_RETURN_DATE_ONE;
+    public static final Date VALID_LOAN_RETURN_DATE_TWO;
+    public static final Date VALID_LOAN_RETURN_DATE_THREE;
+
+    static {
+        try {
+            VALID_LOAN_START_DATE_ONE = DateUtil.parse("2016-08-25");
+            VALID_LOAN_START_DATE_TWO = DateUtil.parse("2024-02-29");
+            VALID_LOAN_START_DATE_THREE = DateUtil.parse("2027-12-15");
+
+            VALID_LOAN_RETURN_DATE_ONE = DateUtil.parse("2020-01-07");
+            VALID_LOAN_RETURN_DATE_TWO = DateUtil.parse("2024-03-31");
+            VALID_LOAN_RETURN_DATE_THREE = DateUtil.parse("2030-06-02");
+        } catch (IllegalValueException e) {
+            throw new RuntimeException(e);
+        }
+    }
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_PHONE_AMY = "11111111";

--- a/src/test/java/seedu/address/logic/commands/DeleteLoanCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteLoanCommandTest.java
@@ -1,4 +1,68 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.testutil.TypicalPersonsWithLoans.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Loan;
+
 public class DeleteLoanCommandTest {
+
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    private final int loanListSize = model.getSortedLoanList().size();
+
+    private final Loan firstLoan = model.getSortedLoanList().get(0);
+
+    @Test
+    public void execute_loanDeleted_success() throws CommandException {
+        assertTrue(model.getSortedLoanList().contains(firstLoan));
+
+        DeleteLoanCommand deleteLoanCommand = new DeleteLoanCommand(Index.fromOneBased(1));
+        CommandResult commandResult = deleteLoanCommand.execute(model);
+        int newSize = model.getSortedLoanList().size();
+
+        assertEquals(loanListSize - 1, newSize);
+        assertFalse(model.getSortedLoanList().contains(firstLoan));
+        assertEquals(String.format(DeleteLoanCommand.MESSAGE_SUCCESS, firstLoan),
+                commandResult.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_invalidLoanIndex_failure() {
+        DeleteLoanCommand deleteLoanCommand = new DeleteLoanCommand(Index.fromOneBased(loanListSize + 1));
+        assertCommandFailure(deleteLoanCommand, model, String.format(DeleteLoanCommand.MESSAGE_FAILURE_LOAN,
+                loanListSize + 1));
+    }
+
+    @Test
+    public void equals() {
+        DeleteLoanCommand deleteLoanFirstCommand = new DeleteLoanCommand(Index.fromOneBased(1));
+        DeleteLoanCommand deleteLoanSecondCommand = new DeleteLoanCommand(Index.fromOneBased(2));
+
+        // same object -> returns true
+        assertTrue(deleteLoanFirstCommand.equals(deleteLoanFirstCommand));
+
+        // same values -> returns true
+        DeleteLoanCommand deleteLoanFirstCommandCopy = new DeleteLoanCommand(Index.fromOneBased(1));
+        assertTrue(deleteLoanFirstCommand.equals(deleteLoanFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(deleteLoanFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(deleteLoanFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(deleteLoanFirstCommand.equals(deleteLoanSecondCommand));
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/EditLoanCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditLoanCommandTest.java
@@ -18,8 +18,8 @@ import static seedu.address.testutil.TypicalPersonsWithLoans.getTypicalAddressBo
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.EditLoanCommand.EditLoanDescriptor;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;

--- a/src/test/java/seedu/address/logic/commands/EditLoanCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditLoanCommandTest.java
@@ -1,0 +1,159 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOAN_RETURN_DATE_ONE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOAN_RETURN_DATE_THREE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOAN_RETURN_DATE_TWO;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOAN_START_DATE_ONE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOAN_START_DATE_THREE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOAN_START_DATE_TWO;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOAN_VALUE_ONE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOAN_VALUE_THREE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOAN_VALUE_TWO;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.testutil.TypicalPersonsWithLoans.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.commands.EditLoanCommand.EditLoanDescriptor;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Loan;
+
+public class EditLoanCommandTest {
+
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    private final int loanListSize = model.getSortedLoanList().size();
+
+    @Test
+    public void execute_allFieldsSpecified_success() throws CommandException {
+        EditLoanDescriptor editLoanDescriptor = new EditLoanDescriptor();
+        editLoanDescriptor.setValue(VALID_LOAN_VALUE_ONE);
+        editLoanDescriptor.setStartDate(VALID_LOAN_START_DATE_ONE);
+        editLoanDescriptor.setReturnDate(VALID_LOAN_RETURN_DATE_ONE);
+
+        EditLoanCommand editLoanCommand = new EditLoanCommand(editLoanDescriptor, Index.fromOneBased(1));
+        CommandResult commandResult = editLoanCommand.execute(model);
+        // Note that as VALID_LOAN_START_DATE_ONE is before all the other dates,
+        // the edited loan is still first in the sorted loan list
+        Loan editedLoan = model.getSortedLoanList().get(0);
+
+        assertEquals(editedLoan.getValue(), VALID_LOAN_VALUE_ONE);
+        assertEquals(editedLoan.getStartDate(), VALID_LOAN_START_DATE_ONE);
+        assertEquals(editedLoan.getReturnDate(), VALID_LOAN_RETURN_DATE_ONE);
+        assertEquals(String.format(EditLoanCommand.MESSAGE_SUCCESS, editedLoan), commandResult.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_onlyValueSpecified_success() throws CommandException {
+        EditLoanDescriptor editLoanDescriptor = new EditLoanDescriptor();
+        editLoanDescriptor.setValue(VALID_LOAN_VALUE_ONE);
+
+        EditLoanCommand editLoanCommand = new EditLoanCommand(editLoanDescriptor, Index.fromOneBased(1));
+        CommandResult commandResult = editLoanCommand.execute(model);
+
+        Loan editedLoan = model.getSortedLoanList().get(0);
+
+        assertEquals(editedLoan.getValue(), VALID_LOAN_VALUE_ONE);
+        assertEquals(String.format(EditLoanCommand.MESSAGE_SUCCESS, editedLoan), commandResult.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_onlyStartDateSpecified_success() throws CommandException {
+        EditLoanDescriptor editLoanDescriptor = new EditLoanDescriptor();
+        editLoanDescriptor.setStartDate(VALID_LOAN_START_DATE_ONE);
+
+        EditLoanCommand editLoanCommand = new EditLoanCommand(editLoanDescriptor, Index.fromOneBased(1));
+        CommandResult commandResult = editLoanCommand.execute(model);
+
+        Loan editedLoan = model.getSortedLoanList().get(0);
+
+        assertEquals(editedLoan.getStartDate(), VALID_LOAN_START_DATE_ONE);
+        assertEquals(String.format(EditLoanCommand.MESSAGE_SUCCESS, editedLoan), commandResult.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_onlyReturnDateSpecified_success() throws CommandException {
+        EditLoanDescriptor editLoanDescriptor = new EditLoanDescriptor();
+        editLoanDescriptor.setReturnDate(VALID_LOAN_RETURN_DATE_ONE);
+
+        EditLoanCommand editLoanCommand = new EditLoanCommand(editLoanDescriptor, Index.fromOneBased(1));
+        CommandResult commandResult = editLoanCommand.execute(model);
+
+        Loan editedLoan = model.getSortedLoanList().get(0);
+
+        assertEquals(editedLoan.getReturnDate(), VALID_LOAN_RETURN_DATE_ONE);
+        assertEquals(String.format(EditLoanCommand.MESSAGE_SUCCESS, editedLoan), commandResult.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_invalidLoanIndex_failure() {
+        EditLoanDescriptor editLoanDescriptor = new EditLoanDescriptor();
+        editLoanDescriptor.setValue(VALID_LOAN_VALUE_ONE);
+        editLoanDescriptor.setStartDate(VALID_LOAN_START_DATE_ONE);
+        editLoanDescriptor.setReturnDate(VALID_LOAN_RETURN_DATE_ONE);
+
+        EditLoanCommand editLoanCommand = new EditLoanCommand(editLoanDescriptor,
+                Index.fromOneBased(loanListSize + 1));
+        assertCommandFailure(editLoanCommand, model, String.format(EditLoanCommand.MESSAGE_FAILURE_LOAN,
+                loanListSize + 1));
+    }
+
+    @Test
+    public void equals() {
+        EditLoanDescriptor editLoanDescriptor = new EditLoanDescriptor();
+        editLoanDescriptor.setValue(VALID_LOAN_VALUE_ONE);
+        editLoanDescriptor.setStartDate(VALID_LOAN_START_DATE_ONE);
+        editLoanDescriptor.setReturnDate(VALID_LOAN_RETURN_DATE_ONE);
+        EditLoanDescriptor copyDescriptor = new EditLoanDescriptor();
+        copyDescriptor.setValue(VALID_LOAN_VALUE_ONE);
+        copyDescriptor.setStartDate(VALID_LOAN_START_DATE_ONE);
+        copyDescriptor.setReturnDate(VALID_LOAN_RETURN_DATE_ONE);
+
+        final EditLoanCommand standardCommand = new EditLoanCommand(editLoanDescriptor,
+                Index.fromOneBased(1));
+        EditLoanCommand commandWithSameValues = new EditLoanCommand(copyDescriptor, Index.fromOneBased(1));
+
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new EditLoanCommand(editLoanDescriptor,
+                Index.fromOneBased(2))));
+
+        // different descriptor -> returns false
+        EditLoanDescriptor differentDescriptor = new EditLoanDescriptor();
+        differentDescriptor.setValue(VALID_LOAN_VALUE_TWO);
+        differentDescriptor.setStartDate(VALID_LOAN_START_DATE_TWO);
+        differentDescriptor.setReturnDate(VALID_LOAN_RETURN_DATE_TWO);
+        assertFalse(standardCommand.equals(new EditLoanCommand(differentDescriptor,
+                Index.fromOneBased(1))));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index index = Index.fromOneBased(1);
+        EditLoanDescriptor editLoanDescriptor = new EditLoanDescriptor();
+        editLoanDescriptor.setValue(VALID_LOAN_VALUE_THREE);
+        editLoanDescriptor.setStartDate(VALID_LOAN_START_DATE_THREE);
+        editLoanDescriptor.setReturnDate(VALID_LOAN_RETURN_DATE_THREE);
+        EditLoanCommand editLoanCommand = new EditLoanCommand(editLoanDescriptor, Index.fromOneBased(1));
+        String expected = EditLoanCommand.class.getCanonicalName() + "{loanIndex=" + index
+                + ", editedDetails=" + editLoanDescriptor + "}";
+        assertEquals(expected, editLoanCommand.toString());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/LinkLoanCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/LinkLoanCommandTest.java
@@ -1,0 +1,103 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOAN_RETURN_DATE_ONE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOAN_RETURN_DATE_THREE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOAN_RETURN_DATE_TWO;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOAN_START_DATE_ONE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOAN_START_DATE_THREE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOAN_START_DATE_TWO;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOAN_VALUE_ONE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOAN_VALUE_THREE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOAN_VALUE_TWO;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.LinkLoanCommand.LinkLoanDescriptor;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Loan;
+import seedu.address.model.person.Person;
+
+public class LinkLoanCommandTest {
+
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    private final Person firstPerson = model.getFilteredPersonList().get(0);
+
+    private final int personListSize = model.getFilteredPersonList().size();
+
+    @Test
+    public void execute_loanLinkedToPerson_success() throws CommandException {
+        LinkLoanDescriptor linkLoanDescriptor = new LinkLoanDescriptor(VALID_LOAN_VALUE_ONE,
+                VALID_LOAN_START_DATE_ONE, VALID_LOAN_RETURN_DATE_ONE);
+        LinkLoanCommand linkLoanCommand = new LinkLoanCommand(linkLoanDescriptor, Index.fromOneBased(1));
+        CommandResult commandResult = linkLoanCommand.execute(model);
+        Loan linkedLoan = model.getSortedLoanList().get(0);
+
+        assertEquals(linkedLoan.getValue(), VALID_LOAN_VALUE_ONE);
+        assertEquals(linkedLoan.getStartDate(), VALID_LOAN_START_DATE_ONE);
+        assertEquals(linkedLoan.getReturnDate(), VALID_LOAN_RETURN_DATE_ONE);
+        assertEquals(linkedLoan.getAssignee(), firstPerson);
+        assertEquals(String.format(LinkLoanCommand.MESSAGE_SUCCESS, firstPerson.getName(),
+                        linkedLoan),
+                commandResult.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_invalidPersonIndex_failure() {
+        LinkLoanDescriptor linkLoanDescriptor = new LinkLoanDescriptor(VALID_LOAN_VALUE_ONE,
+                VALID_LOAN_START_DATE_ONE, VALID_LOAN_RETURN_DATE_ONE);
+        LinkLoanCommand linkLoanCommand = new LinkLoanCommand(linkLoanDescriptor,
+                Index.fromOneBased(personListSize + 1));
+        assertCommandFailure(linkLoanCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        LinkLoanDescriptor linkLoanDescriptor = new LinkLoanDescriptor(VALID_LOAN_VALUE_ONE,
+                VALID_LOAN_START_DATE_ONE, VALID_LOAN_RETURN_DATE_ONE);
+        LinkLoanDescriptor copyDescriptor = new LinkLoanDescriptor(linkLoanDescriptor);
+        final LinkLoanCommand standardCommand = new LinkLoanCommand(linkLoanDescriptor, Index.fromOneBased(1));
+        LinkLoanCommand commandWithSameValues = new LinkLoanCommand(copyDescriptor, Index.fromOneBased(1));
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new LinkLoanCommand(linkLoanDescriptor, Index.fromOneBased(2))));
+
+        // different descriptor -> returns false
+        assertFalse(standardCommand.equals(new LinkLoanCommand(new LinkLoanDescriptor(
+                VALID_LOAN_VALUE_TWO,
+                VALID_LOAN_START_DATE_TWO,
+                VALID_LOAN_RETURN_DATE_TWO), Index.fromOneBased(1))));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index index = Index.fromOneBased(1);
+        LinkLoanDescriptor linkLoanDescriptor = new LinkLoanDescriptor(VALID_LOAN_VALUE_THREE,
+                VALID_LOAN_START_DATE_THREE, VALID_LOAN_RETURN_DATE_THREE);
+        LinkLoanCommand linkLoanCommand = new LinkLoanCommand(linkLoanDescriptor, Index.fromOneBased(1));
+        String expected = LinkLoanCommand.class.getCanonicalName() + "{linkTarget=" + index
+                + ", loanDescription=" + linkLoanDescriptor + "}";
+        assertEquals(expected, linkLoanCommand.toString());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/LinkLoanCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/LinkLoanCommandTest.java
@@ -18,7 +18,6 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.LinkLoanCommand.LinkLoanDescriptor;
 import seedu.address.logic.commands.exceptions.CommandException;

--- a/src/test/java/seedu/address/logic/commands/UnmarkLoanCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnmarkLoanCommandTest.java
@@ -15,12 +15,7 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Loan;
 
-
-/**
- * Contains integration tests (interaction with the Model) and unit tests for MarkLoanCommand.
- */
-public class MarkLoanCommandTest {
-
+public class UnmarkLoanCommandTest {
     private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     private final int loanListSize = model.getSortedLoanList().size();
@@ -28,43 +23,46 @@ public class MarkLoanCommandTest {
     private final Loan firstLoan = model.getSortedLoanList().get(0);
 
     @Test
-    public void execute_markLoanAsReturned_success() throws CommandException {
-        assertTrue(firstLoan.isActive());
-
+    public void execute_unmarkLoanAsReturned_success() throws CommandException {
         MarkLoanCommand markLoanCommand = new MarkLoanCommand(Index.fromOneBased(1));
-        CommandResult commandResult = markLoanCommand.execute(model);
+        markLoanCommand.execute(model);
 
         assertTrue(firstLoan.isReturned());
-        assertEquals(String.format(MarkLoanCommand.MESSAGE_SUCCESS, firstLoan),
+
+        UnmarkLoanCommand unmarkLoanCommand = new UnmarkLoanCommand(Index.fromOneBased(1));
+        CommandResult commandResult = unmarkLoanCommand.execute(model);
+
+        assertTrue(firstLoan.isActive());
+        assertEquals(String.format(unmarkLoanCommand.MESSAGE_SUCCESS, firstLoan),
                 commandResult.getFeedbackToUser());
     }
 
     @Test
     public void execute_invalidLoanIndex_failure() {
-        MarkLoanCommand markLoanCommand = new MarkLoanCommand(Index.fromOneBased(loanListSize + 1));
-        assertCommandFailure(markLoanCommand, model, String.format(MarkLoanCommand.MESSAGE_FAILURE_LOAN,
+        UnmarkLoanCommand unmarkLoanCommand = new UnmarkLoanCommand(Index.fromOneBased(loanListSize + 1));
+        assertCommandFailure(unmarkLoanCommand, model, String.format(unmarkLoanCommand.MESSAGE_FAILURE_LOAN,
                 loanListSize + 1));
     }
 
     @Test
     public void equals() {
-        MarkLoanCommand markLoanFirstCommand = new MarkLoanCommand(Index.fromOneBased(1));
-        MarkLoanCommand markLoanSecondCommand = new MarkLoanCommand(Index.fromOneBased(2));
+        UnmarkLoanCommand unmarkLoanFirstCommand = new UnmarkLoanCommand(Index.fromOneBased(1));
+        UnmarkLoanCommand unmarkLoanSecondCommand = new UnmarkLoanCommand(Index.fromOneBased(2));
 
         // same object -> returns true
-        assertTrue(markLoanFirstCommand.equals(markLoanFirstCommand));
+        assertTrue(unmarkLoanFirstCommand.equals(unmarkLoanFirstCommand));
 
         // same values -> returns true
-        MarkLoanCommand markLoanFirstCommandCopy = new MarkLoanCommand(Index.fromOneBased(1));
-        assertTrue(markLoanFirstCommand.equals(markLoanFirstCommandCopy));
+        UnmarkLoanCommand unmarkLoanFirstCommandCopy = new UnmarkLoanCommand(Index.fromOneBased(1));
+        assertTrue(unmarkLoanFirstCommand.equals(unmarkLoanFirstCommandCopy));
 
         // different types -> returns false
-        assertFalse(markLoanFirstCommand.equals(1));
+        assertFalse(unmarkLoanFirstCommand.equals(1));
 
         // null -> returns false
-        assertFalse(markLoanFirstCommand.equals(null));
+        assertFalse(unmarkLoanFirstCommand.equals(null));
 
         // different person -> returns false
-        assertFalse(markLoanFirstCommand.equals(markLoanSecondCommand));
+        assertFalse(unmarkLoanFirstCommand.equals(unmarkLoanSecondCommand));
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersonsWithLoans.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersonsWithLoans.java
@@ -26,7 +26,6 @@ import seedu.address.model.person.UniqueLoanList;
  * A utility class containing a list of {@code Person} objects to be used in tests.
  */
 public class TypicalPersonsWithLoans {
-    public static final UniqueLoanList LOAN_RECORDS = loanRecords();
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
             .withPhone("94351253")


### PR DESCRIPTION
Partial fix for #204.

Adds test cases for the `linkloan`, `editloan`, `deleteloan`, `markloan` and `unmarkloan` commands, as well as general test code quality improvements (e.g. reworking of constants).

Also fixed a bug where circular reference in the `TypicalPersonsWithLoans` class was causing some fields to not initialise upon class methods being called.