### PR TITLE
Add toString tests to MarkLoanCommand, UnmarkLoanCommand and DeleteLoanCommand

### DIFF
--- a/src/test/java/seedu/address/logic/commands/DeleteLoanCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteLoanCommandTest.java
@@ -65,4 +65,12 @@ public class DeleteLoanCommandTest {
         // different person -> returns false
         assertFalse(deleteLoanFirstCommand.equals(deleteLoanSecondCommand));
     }
+
+    @Test
+    public void toStringMethod() {
+        Index index = Index.fromOneBased(1);
+        DeleteLoanCommand deleteLoanCommand = new DeleteLoanCommand(index);
+        String expected = DeleteLoanCommand.class.getCanonicalName() + "{loanIndex=" + index + "}";
+        assertEquals(expected, deleteLoanCommand.toString());
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/MarkLoanCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkLoanCommandTest.java
@@ -67,4 +67,12 @@ public class MarkLoanCommandTest {
         // different person -> returns false
         assertFalse(markLoanFirstCommand.equals(markLoanSecondCommand));
     }
+
+    @Test
+    public void toStringMethod() {
+        Index index = Index.fromOneBased(1);
+        MarkLoanCommand markLoanCommand = new MarkLoanCommand(index);
+        String expected = MarkLoanCommand.class.getCanonicalName() + "{loanIndex=" + index + "}";
+        assertEquals(expected, markLoanCommand.toString());
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/UnmarkLoanCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnmarkLoanCommandTest.java
@@ -65,4 +65,12 @@ public class UnmarkLoanCommandTest {
         // different person -> returns false
         assertFalse(unmarkLoanFirstCommand.equals(unmarkLoanSecondCommand));
     }
+
+    @Test
+    public void toStringMethod() {
+        Index index = Index.fromOneBased(1);
+        UnmarkLoanCommand unmarkLoanCommand = new UnmarkLoanCommand(index);
+        String expected = UnmarkLoanCommand.class.getCanonicalName() + "{loanIndex=" + index + "}";
+        assertEquals(expected, unmarkLoanCommand.toString());
+    }
 }


### PR DESCRIPTION
Adds toString tests to the `MarkLoanCommandTest`, `UnmarkLoanCommandTest` and `DeleteLoanCommandTest` classes, to standardise unit tests with the other commands.