### PR TITLE
Fix incorrect assertions in DashboardData

### DIFF
--- a/src/main/java/seedu/address/model/analytics/DashboardData.java
+++ b/src/main/java/seedu/address/model/analytics/DashboardData.java
@@ -18,9 +18,9 @@ import seedu.address.model.person.Analytics;
  * - Earliest return date
  */
 public class DashboardData {
-    private Analytics analytics;
-    private BigDecimal maxLoanValue;
-    private Date earliestReturnDate;
+    private final Analytics analytics;
+    private final BigDecimal maxLoanValue;
+    private final Date earliestReturnDate;
 
     /**
      * Creates a DashboardData object with the given analytics, max loan value and earliest return date
@@ -31,13 +31,8 @@ public class DashboardData {
      */
     public DashboardData(Analytics analytics, BigDecimal maxLoanValue, Date earliestReturnDate) {
         requireNonNull(analytics);
-        requireNonNull(maxLoanValue);
         this.analytics = analytics;
         this.maxLoanValue = maxLoanValue;
-        // Should never be over the current date since overdue loans are not included
-        if (earliestReturnDate.before(new Date())) {
-            throw new IllegalArgumentException("Earliest return date should be in the future");
-        }
         this.earliestReturnDate = earliestReturnDate;
     }
 

--- a/src/test/java/seedu/address/model/analytics/DashboardDataTest.java
+++ b/src/test/java/seedu/address/model/analytics/DashboardDataTest.java
@@ -23,16 +23,6 @@ public class DashboardDataTest {
     }
 
     @Test
-    public void constructor_overdueReturnDate_throwsIllegalArgumentException() {
-        Analytics analytics = Analytics.getAnalytics(new UniqueLoanList().asUnmodifiableObservableList());
-        // Earliest return date in whole database is earlier than now
-        // Loan is overdue and should not be considered
-        Date oneDayBeforeNow = new Date(new Date().getTime() - 86400000);
-        assertThrows(IllegalArgumentException.class, () -> new DashboardData(analytics,
-                new BigDecimal("100"), oneDayBeforeNow));
-    }
-
-    @Test
     public void urgencyTest() {
         Date oneWeekAfterNow = new Date(new Date().getTime() + 604800000);
         Date twoWeeksAfterNow = new Date(new Date().getTime() + 1209600000);


### PR DESCRIPTION
DashboardData's constructor throws an IllegalArgumentException even though the date is not overdue. This is caused by having a loan in the database that is due on the same day as today.

The `throw IllegalArgumentException` has been removed as we can ensure that the value passed into the constructor is always valid.