### PR TITLE
Improve Javadoc comments

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AnalyticsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AnalyticsCommand.java
@@ -27,6 +27,9 @@ public class AnalyticsCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Analytics generated";
     private final Index targetIndex;
 
+    /**
+     * @param targetIndex The index of the person to view analytics for.
+     */
     public AnalyticsCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
     }
@@ -35,6 +38,7 @@ public class AnalyticsCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
+        assert lastShownList != null;
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/DeleteLoanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteLoanCommand.java
@@ -28,7 +28,7 @@ public class DeleteLoanCommand extends Command {
 
     /**
      * Creates a DeleteLoanCommand to delete the specified loan.
-     * @param loanIndex index of the loan in the last shown loan list.
+     * @param loanIndex Index of the loan in the last shown loan list.
      */
     public DeleteLoanCommand(Index loanIndex) {
         requireAllNonNull(loanIndex);
@@ -37,8 +37,8 @@ public class DeleteLoanCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         List<Loan> lastShownList = model.getSortedLoanList();
+        assert lastShownList != null;
         if (loanIndex.getZeroBased() >= lastShownList.size()) {
-            // in reality, it's loan index outside of list range. We will be concerned about it later.
             throw new CommandException(String.format(MESSAGE_FAILURE_LOAN, loanIndex.getOneBased()));
         }
         // delete specified loan number
@@ -48,8 +48,7 @@ public class DeleteLoanCommand extends Command {
     }
 
     /**
-     * Generates a command execution success message after loan is deleted from the
-     * {@code personToEdit}.
+     * Generates a command execution success message after loan is deleted.
      */
     private String generateSuccessMessage(Loan removedLoan) {
         return String.format(MESSAGE_SUCCESS, removedLoan);

--- a/src/main/java/seedu/address/logic/commands/EditLoanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditLoanCommand.java
@@ -79,8 +79,11 @@ public class EditLoanCommand extends Command {
 
         Loan loanToEdit = lastShownList.get(loanIndex.getZeroBased());
         Person linkedPerson = loanToEdit.getAssignee();
+        // Generate updated details of the loan
         LinkLoanDescriptor updatedLoanDetails = generateEditedLoanDetails(loanToEdit, editedDetails);
+        // Delete the old loan
         model.deleteLoan(loanToEdit);
+        // Create and link a new loan using the updated loan details
         Loan editedLoan = model.addLoan(updatedLoanDetails, linkedPerson);
 
         return new CommandResult(generateSuccessMessage(editedLoan), false, false, true);
@@ -93,6 +96,14 @@ public class EditLoanCommand extends Command {
         return String.format(MESSAGE_SUCCESS, editedLoan);
     }
 
+    /**
+     * Generates the new loan details in the form of a LinkLoanDescriptor.
+     *
+     * @param loanToEdit The original loan that was edited.
+     * @param editedDetails The details of the loan that were changed.
+     * @return All details of the new loan, including the changed and unchanged details.
+     * @throws CommandException If the edited date(s) are invalid.
+     */
     private LinkLoanDescriptor generateEditedLoanDetails(Loan loanToEdit, EditLoanDescriptor editedDetails)
             throws CommandException {
         BigDecimal newValue = editedDetails.getValue().orElse(loanToEdit.getValue());

--- a/src/main/java/seedu/address/logic/commands/LinkLoanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LinkLoanCommand.java
@@ -66,6 +66,7 @@ public class LinkLoanCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
+        assert lastShownList != null;
 
         if (linkTarget.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/MarkLoanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkLoanCommand.java
@@ -27,8 +27,8 @@ public class MarkLoanCommand extends Command {
     private final Index loanIndex;
 
     /**
-     * Creates a MarkLoanCommand to delete the specified loan.
-     * @param loanIndex
+     * Creates a MarkLoanCommand to mark the specified loan.
+     * @param loanIndex Index of the loan in the last shown loan list.
      */
     public MarkLoanCommand(Index loanIndex) {
         requireAllNonNull(loanIndex);
@@ -38,19 +38,18 @@ public class MarkLoanCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         List<Loan> lastShownList = model.getSortedLoanList();
+        assert lastShownList != null;
         if (loanIndex.getZeroBased() >= lastShownList.size()) {
-            // in reality, it's loan index outside of list range. We will be concerned about it later.
             throw new CommandException(String.format(MESSAGE_FAILURE_LOAN, loanIndex.getOneBased()));
         }
-        // delete specified loan number
+        // mark specified loan number
         Loan loanToMark = lastShownList.get(loanIndex.getZeroBased());
         model.markLoan(loanToMark);
         return new CommandResult(generateSuccessMessage(loanToMark), false, false, true);
     }
 
     /**
-     * Generates a command execution success message after loan is deleted from the
-     * {@code personToEdit}.
+     * Generates a command execution success message after loan is marked.
      */
     private String generateSuccessMessage(Loan markedLoan) {
         return String.format(MESSAGE_SUCCESS, markedLoan);

--- a/src/main/java/seedu/address/logic/commands/UnmarkLoanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkLoanCommand.java
@@ -26,8 +26,8 @@ public class UnmarkLoanCommand extends Command {
     private final Index loanIndex;
 
     /**
-     * Creates a UnmarkLoanCommand to delete the specified loan.
-     * @param loanIndex
+     * Creates a UnmarkLoanCommand to unmark the specified loan.
+     * @param loanIndex Index of the loan in the last shown loan list.
      */
     public UnmarkLoanCommand(Index loanIndex) {
         requireAllNonNull(loanIndex);
@@ -37,19 +37,18 @@ public class UnmarkLoanCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         List<Loan> lastShownList = model.getSortedLoanList();
+        assert lastShownList != null;
         if (loanIndex.getZeroBased() >= lastShownList.size()) {
-            // in reality, it's loan index outside of list range. We will be concerned about it later.
             throw new CommandException(String.format(MESSAGE_FAILURE_LOAN, loanIndex.getOneBased()));
         }
-        // delete specified loan number
+        // unmark specified loan number
         Loan loanToUnmark = lastShownList.get(loanIndex.getZeroBased());
         model.unmarkLoan(loanToUnmark);
         return new CommandResult(generateSuccessMessage(loanToUnmark), false, false, true);
     }
 
     /**
-     * Generates a command execution success message after loan is deleted from the
-     * {@code personToEdit}.
+     * Generates a command execution success message after loan is unmarked.
      */
     private String generateSuccessMessage(Loan markedLoan) {
         return String.format(MESSAGE_SUCCESS, markedLoan);

--- a/src/main/java/seedu/address/logic/commands/ViewLoanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewLoanCommand.java
@@ -38,6 +38,7 @@ public class ViewLoanCommand extends ViewLoanRelatedCommand {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
+        assert lastShownList != null;
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/ViewLoansCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewLoansCommand.java
@@ -9,10 +9,12 @@ import seedu.address.model.Model;
  * Lists all active loans in the address book to the user.
  */
 public class ViewLoansCommand extends ViewLoanRelatedCommand {
-    public static final String COMMAND_WORD = "viewloans";
 
     public static final String MESSAGE_SUCCESS = "Listed all loans";
 
+    /**
+     * @param isShowAllLoans Whether to show all loans or only active loans.
+     */
     public ViewLoansCommand(boolean isShowAllLoans) {
         super(isShowAllLoans);
     }


### PR DESCRIPTION
- Fixes typoes in Javadoc comments for the loan functions.
- Adds explanations for some commands in comments.
- Adds assertions that the lists retrieved are not `null`.